### PR TITLE
fix image upload file name

### DIFF
--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -310,6 +310,7 @@ export default {
       }
     },
     uploadCompleted (fileIndex, fileName, fileType, fileUrl) {
+      fileName = fileName.replace(/[\[\]]/g, '_')
       this.comment = this.comment.replace(this.getImagePlaceholder(fileIndex, fileType), `![${fileName}](${fileUrl})`)
       this.$refs.inputFile.value = ''
     },


### PR DESCRIPTION
twikoo粘贴图片时默认将图片文件名插入md中，而用户从QQ复制的图片文件名中可能包含中括号导致markdown不能正常解析
![image](https://github.com/imaegoo/twikoo/assets/13391795/ccaa191b-dd96-496d-bc33-510bcaae1f72)
