### PR TITLE
fix: get qq anonymous avatar

### DIFF
--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -154,11 +154,8 @@ const fn = {
   async getQQAvatar (qq) {
     try {
       const qqNum = qq.replace(/@qq.com/ig, '')
-      const result = await axios.get(`https://s.p.qq.com/pub/get_face?img_type=4&uin=${qqNum}`, {
-        maxRedirects: 0,
-        validateStatus: status => [301, 302, 307, 308].includes(status)
-      })
-      return result?.headers?.location || null
+      const result = await axios.get(`https://aq.qq.com/cn2/get_img/get_face?img_type=3&uin=${qqNum}`)
+      return result.data?.url || null
     } catch (e) {
       logger.warn('获取 QQ 头像失败：', e)
     }


### PR DESCRIPTION
之前在 #565 使用的获取匿名头像接口又失效了。
所以我又换了个其他接口。

这个接口 `img_type` 参数为 `3` 时返回 100 x 100 大小的头像。
其他值均返回 40 x 40 大小的头像。