### PR TITLE
feat: add `href` option

### DIFF
--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -94,6 +94,10 @@ const getUrl = (path) => {
   return url
 }
 
+const getHref = (href) => {
+  return window.TWIKOO_MAGIC_HREF ?? href ?? window.location.href
+}
+
 /**
  * 读取文本文件内容
  */
@@ -173,6 +177,7 @@ export {
   getCommentsCountApi,
   getRecentCommentsApi,
   getUrl,
+  getHref,
   readAsText,
   renderLinks,
   renderMath,

--- a/src/client/view/components/TkFooter.vue
+++ b/src/client/view/components/TkFooter.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { version } from '../../version'
-import { call, getUrl } from '../../utils'
+import { call, getUrl, getHref } from '../../utils'
 
 export default {
   data () {
@@ -22,9 +22,10 @@ export default {
       if (!counterEl) return
       if (['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1) return
       const url = getUrl(this.$twikoo.path)
+      const href = getHref(this.$twikoo.href)
       const result = await call(this.$tcb, 'COUNTER_GET', {
         url,
-        href: window.location.href,
+        href,
         title: document.title
       })
       this.counter = result.result

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -53,7 +53,7 @@ import iconImage from '@fortawesome/fontawesome-free/svgs/regular/image.svg'
 import Clickoutside from 'element-ui/src/utils/clickoutside'
 import TkAvatar from './TkAvatar.vue'
 import TkMetaInput from './TkMetaInput.vue'
-import { marked, call, logger, renderLinks, renderMath, renderCode, initOwoEmotion, initMarkedOwo, t, getUrl, blobToDataURL } from '../../utils'
+import { marked, call, logger, renderLinks, renderMath, renderCode, initOwoEmotion, initMarkedOwo, t, getUrl, getHref, blobToDataURL } from '../../utils'
 import OwO from '../../lib/owo'
 
 const imageTypes = [
@@ -180,13 +180,14 @@ export default {
           throw new Error(t('IMAGE_UPLOAD_PLEASE_WAIT'))
         }
         const url = getUrl(this.$twikoo.path)
+        const href = getHref(this.$twikoo.href)
         const comment = {
           nick: this.nick,
           mail: this.mail,
           link: this.link,
           ua: navigator.userAgent,
           url,
-          href: window.location.href,
+          href,
           comment: marked(this.comment),
           pid: this.pid ? this.pid : this.replyId,
           rid: this.replyId


### PR DESCRIPTION
## 描述

在有**镜像站点**的情况下，允许管理员规范邮件通知使用的网址。

为前端 `twikoo.init` 方法新增 `href` 选项。
以及全局覆盖变量 `TWIKOO_MAGIC_HREF`。
用于指定相关接口的 `href` 参数。

尝试解决从镜像站点发送评论时，邮件通知里网址不统一的情况。
也就是模板中的 `${POST_URL}` 变量。

## 使用示例

先自定义获取理想网址的方法。
```js
const getHref = () => {
  const url = new URL(location);
  url.protocol = 'https:';
  url.hostname = 'example.com';
  url.port = '';
  return url.href;
};
```

然后在初始化评论区时调用并传入 `href` 选项。
```js
twikoo.init({
  envId: 'https://comment.example.com',
  el: '#tcomment',
  href: getHref()
});
```

或者直接在网页中声明全局变量进行覆盖。
```js
Object.defineProperty(window, 'TWIKOO_MAGIC_HREF', {
    configurable: true,
    get: getHref
});
```