### PR TITLE
fix: normalized mail

### DIFF
--- a/src/client/utils/avatar.js
+++ b/src/client/utils/avatar.js
@@ -1,3 +1,7 @@
+function normalizeMail (mail) {
+  return String(mail).trim().toLowerCase()
+}
+
 function isQQ (mail) {
   return /^[1-9][0-9]{4,10}$/.test(mail) ||
     /^[1-9][0-9]{4,10}@qq.com$/i.test(mail)
@@ -9,6 +13,7 @@ function getQQAvatar (qq) {
 }
 
 export {
+  normalizeMail,
   isQQ,
   getQQAvatar
 }

--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -3,7 +3,7 @@ import timeago from './timeago'
 import marked from './marked'
 import renderCode from './highlight'
 import { isUrl, call } from './api'
-import { isQQ, getQQAvatar } from './avatar'
+import { normalizeMail, isQQ, getQQAvatar } from './avatar'
 import { initOwoEmotion, initMarkedOwo } from './emotion'
 
 const isNotSet = (option) => {
@@ -166,6 +166,7 @@ export {
   isUrl,
   call,
   getFuncVer,
+  normalizeMail,
   isQQ,
   getQQAvatar,
   initOwoEmotion,

--- a/src/client/view/components/TkAvatar.vue
+++ b/src/client/view/components/TkAvatar.vue
@@ -7,7 +7,7 @@
 
 <script>
 import md5 from 'blueimp-md5'
-import { convertLink, isQQ, getQQAvatar } from '../../utils'
+import { convertLink, normalizeMail, isQQ, getQQAvatar } from '../../utils'
 import iconUser from '@fortawesome/fontawesome-free/svgs/solid/user-circle.svg'
 
 export default {
@@ -46,7 +46,7 @@ export default {
       } else if (this.mail && isQQ(this.mail)) {
         return getQQAvatar(this.mail)
       } else if (this.mail) {
-        return `https://${this.gravatarCdn}/avatar/${md5(this.mail)}?d=${this.defaultGravatar}`
+        return `https://${this.gravatarCdn}/avatar/${md5(normalizeMail(this.mail))}?d=${this.defaultGravatar}`
       } else {
         return ''
       }

--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -18,6 +18,8 @@ const {
   getUrlsQuery,
   parseComment,
   parseCommentForAdmin,
+  normalizeMail,
+  equalsMail,
   getMailMd5,
   getAvatar,
   isQQ,
@@ -610,13 +612,13 @@ async function postSubmit (comment, context) {
 async function parse (comment) {
   const timestamp = Date.now()
   const isAdminUser = await isAdmin()
-  const isBloggerMail = comment.mail && comment.mail === config.BLOGGER_EMAIL
+  const isBloggerMail = equalsMail(comment.mail, config.BLOGGER_EMAIL)
   if (isBloggerMail && !isAdminUser) throw new Error('请先登录管理面板，再使用博主身份发送评论')
   const commentDo = {
     uid: await getUid(),
     nick: comment.nick ? comment.nick : '匿名',
     mail: comment.mail ? comment.mail : '',
-    mailMd5: comment.mail ? md5(comment.mail) : '',
+    mailMd5: comment.mail ? md5(normalizeMail(comment.mail)) : '',
     link: comment.link ? comment.link : '',
     ua: comment.ua,
     ip: auth.getClientIP(),
@@ -632,7 +634,7 @@ async function parse (comment) {
   }
   if (isQQ(comment.mail)) {
     commentDo.mail = addQQMailSuffix(comment.mail)
-    commentDo.mailMd5 = md5(commentDo.mail)
+    commentDo.mailMd5 = md5(normalizeMail(commentDo.mail))
     commentDo.avatar = await getQQAvatar(comment.mail)
   }
   return commentDo

--- a/src/server/function/twikoo/utils/import.js
+++ b/src/server/function/twikoo/utils/import.js
@@ -1,4 +1,4 @@
-const { getRelativeUrl } = require('.')
+const { getRelativeUrl, normalizeMail } = require('.')
 const { marked, getDomPurify, md5 } = require('./lib')
 
 const fn = {
@@ -153,7 +153,7 @@ const fn = {
           nick: comment.nick,
           ip: comment.ip,
           mail: comment.email,
-          mailMd5: md5(comment.email),
+          mailMd5: md5(normalizeMail(comment.email)),
           isSpam: false,
           ua: comment.ua || '',
           link: comment.link,
@@ -200,7 +200,7 @@ const fn = {
           nick: comment.nick,
           ip: comment.ip,
           mail: comment.email,
-          mailMd5: md5(comment.email),
+          mailMd5: md5(normalizeMail(comment.email)),
           isSpam: comment.is_pending === 'true',
           ua: comment.ua || '',
           link: comment.link,

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -121,12 +121,19 @@ const fn = {
       return url
     }
   },
+  normalizeMail (mail) {
+    return String(mail).trim().toLowerCase()
+  },
+  equalsMail (mail1, mail2) {
+    if (!mail1 || !mail2) return false
+    return fn.normalizeMail(mail1) === fn.normalizeMail(mail2)
+  },
   getMailMd5 (comment) {
     if (comment.mailMd5) {
       return comment.mailMd5
     }
     if (comment.mail) {
-      return md5(comment.mail)
+      return md5(fn.normalizeMail(comment.mail))
     }
     return md5(comment.nick)
   },

--- a/src/server/function/twikoo/utils/notify.js
+++ b/src/server/function/twikoo/utils/notify.js
@@ -1,4 +1,4 @@
-const { getAvatar } = require('.')
+const { equalsMail, getAvatar } = require('.')
 const {
   $,
   nodemailer,
@@ -66,7 +66,7 @@ const fn = {
       logger.info('未配置邮箱或邮箱配置有误，不通知')
       return
     }
-    if (config.BLOGGER_EMAIL && config.BLOGGER_EMAIL === comment.mail) {
+    if (equalsMail(config.BLOGGER_EMAIL, comment.mail)) {
       logger.info('博主本人评论，不发送通知给博主')
       return
     }
@@ -127,7 +127,7 @@ const fn = {
       logger.info('没有配置 pushoo，放弃即时消息通知')
       return
     }
-    if (config.BLOGGER_EMAIL && config.BLOGGER_EMAIL === comment.mail) {
+    if (equalsMail(config.BLOGGER_EMAIL, comment.mail)) {
       logger.info('博主本人评论，不发送通知给博主')
       return
     }
@@ -178,11 +178,11 @@ const fn = {
       return
     }
     const parentComment = await getParentComment(currentComment)
-    if (config.BLOGGER_EMAIL === parentComment.mail) {
+    if (equalsMail(config.BLOGGER_EMAIL, parentComment.mail)) {
       logger.info('回复给博主，因为会发博主通知邮件，所以不再重复通知')
       return
     }
-    if (currentComment.mail === parentComment.mail) {
+    if (equalsMail(currentComment.mail, parentComment.mail)) {
       logger.info('回复自己的评论，不邮件通知')
       return
     }

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -23,6 +23,8 @@ const {
   getUrlsQuery,
   parseComment,
   parseCommentForAdmin,
+  normalizeMail,
+  equalsMail,
   getMailMd5,
   getAvatar,
   isQQ,
@@ -647,14 +649,14 @@ async function postSubmit (comment) {
 async function parse (comment, request) {
   const timestamp = Date.now()
   const isAdminUser = isAdmin(request.body.accessToken)
-  const isBloggerMail = comment.mail && comment.mail === config.BLOGGER_EMAIL
+  const isBloggerMail = equalsMail(comment.mail, config.BLOGGER_EMAIL)
   if (isBloggerMail && !isAdminUser) throw new Error('请先登录管理面板，再使用博主身份发送评论')
   const commentDo = {
     _id: uuidv4().replace(/-/g, ''),
     uid: request.body.accessToken,
     nick: comment.nick ? comment.nick : '匿名',
     mail: comment.mail ? comment.mail : '',
-    mailMd5: comment.mail ? md5(comment.mail) : '',
+    mailMd5: comment.mail ? md5(normalizeMail(comment.mail)) : '',
     link: comment.link ? comment.link : '',
     ua: comment.ua,
     ip: getIp(request),
@@ -670,7 +672,7 @@ async function parse (comment, request) {
   }
   if (isQQ(comment.mail)) {
     commentDo.mail = addQQMailSuffix(comment.mail)
-    commentDo.mailMd5 = md5(commentDo.mail)
+    commentDo.mailMd5 = md5(normalizeMail(commentDo.mail))
     commentDo.avatar = await getQQAvatar(comment.mail)
   }
   return commentDo

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -21,6 +21,8 @@ const {
   getUrlsQuery,
   parseComment,
   parseCommentForAdmin,
+  normalizeMail,
+  equalsMail,
   getMailMd5,
   getAvatar,
   isQQ,
@@ -629,14 +631,14 @@ async function postSubmit (comment) {
 async function parse (comment, request) {
   const timestamp = Date.now()
   const isAdminUser = isAdmin(request.body.accessToken)
-  const isBloggerMail = comment.mail && comment.mail === config.BLOGGER_EMAIL
+  const isBloggerMail = equalsMail(comment.mail, config.BLOGGER_EMAIL)
   if (isBloggerMail && !isAdminUser) throw new Error('请先登录管理面板，再使用博主身份发送评论')
   const commentDo = {
     _id: uuidv4().replace(/-/g, ''),
     uid: request.body.accessToken,
     nick: comment.nick ? comment.nick : '匿名',
     mail: comment.mail ? comment.mail : '',
-    mailMd5: comment.mail ? md5(comment.mail) : '',
+    mailMd5: comment.mail ? md5(normalizeMail(comment.mail)) : '',
     link: comment.link ? comment.link : '',
     ua: comment.ua,
     ip: getIp(request),
@@ -652,7 +654,7 @@ async function parse (comment, request) {
   }
   if (isQQ(comment.mail)) {
     commentDo.mail = addQQMailSuffix(comment.mail)
-    commentDo.mailMd5 = md5(commentDo.mail)
+    commentDo.mailMd5 = md5(normalizeMail(commentDo.mail))
     commentDo.avatar = await getQQAvatar(comment.mail)
   }
   return commentDo

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -22,6 +22,8 @@ const {
   getUrlsQuery,
   parseComment,
   parseCommentForAdmin,
+  normalizeMail,
+  equalsMail,
   getMailMd5,
   getAvatar,
   isQQ,
@@ -649,14 +651,14 @@ async function postSubmit (comment, request) {
 async function parse (comment, request) {
   const timestamp = Date.now()
   const isAdminUser = isAdmin()
-  const isBloggerMail = comment.mail && comment.mail === config.BLOGGER_EMAIL
+  const isBloggerMail = equalsMail(comment.mail, config.BLOGGER_EMAIL)
   if (isBloggerMail && !isAdminUser) throw new Error('请先登录管理面板，再使用博主身份发送评论')
   const commentDo = {
     _id: uuidv4().replace(/-/g, ''),
     uid: getUid(),
     nick: comment.nick ? comment.nick : '匿名',
     mail: comment.mail ? comment.mail : '',
-    mailMd5: comment.mail ? md5(comment.mail) : '',
+    mailMd5: comment.mail ? md5(normalizeMail(comment.mail)) : '',
     link: comment.link ? comment.link : '',
     ua: comment.ua,
     ip: getIp(request),
@@ -672,7 +674,7 @@ async function parse (comment, request) {
   }
   if (isQQ(comment.mail)) {
     commentDo.mail = addQQMailSuffix(comment.mail)
-    commentDo.mailMd5 = md5(commentDo.mail)
+    commentDo.mailMd5 = md5(normalizeMail(commentDo.mail))
     commentDo.avatar = await getQQAvatar(comment.mail)
   }
   return commentDo


### PR DESCRIPTION
## 描述
在进行电子邮箱地址相关的部分操作前，进行规范化处理。

Fix #585，已涵盖 #590。

## 原因
1. 电子邮箱地址本就不区分大小写。
2. 参考 [Creating the Hash - Gravatar](https://cn.gravatar.com/site/implement/hash/) 和 [创建哈希值（Hash） - Cravatar](https://cravatar.com/developer/creating-the-hash)，计算哈希值前应规范化处理。
3. 不会因为大小写不同，导致博主标识不显示了。
4. 不用提醒访客，注意填写小写邮箱才能显示头像了。
5. 参考同类项目，保留了用户在大小写上体现个性，所以我放弃了强制小写邮箱的方案。