### PR TITLE
fix: export from loki should not include meta

### DIFF
--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -517,7 +517,7 @@ async function commentExportForAdmin (event) {
       .getCollection(collection)
       .chain()
       .find({})
-      .data()
+      .data({ removeMeta: true })
     res.code = RES_CODE.SUCCESS
     res.data = data
   } else {


### PR DESCRIPTION
在私有部署，从 [Loki](https://github.com/techfort/LokiJS) 数据库导出数据时，包含了元信息。
```json
"meta": {
  "revision": 0,
  "created": 1672531200000,
  "version": 0
},
"$loki": 1
```
在导入其他数据库时，这部分数据可能会产生冲突或错误。
比如在 [MongoDB](https://mongodb.com) 会报错 `key $loki must not start with '$'`。

我认为导出时，可以不包含这些非关键数据。
根据文档 [Class: Resultset - Method: data](https://techfort.github.io/LokiJS/Resultset.html#data) 用 `removeMeta` 选项可以实现。