### PR TITLE
功能添加与修改

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vue": "^2.6.14",
     "vue-loader": "^15.9.8",
     "vue-template-compiler": "^2.6.14",
-    "webpack": "^5.63.0",
+    "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.4.0"

--- a/src/client/utils/highlight.js
+++ b/src/client/utils/highlight.js
@@ -12,8 +12,8 @@ const renderCode = (el, theme) => {
     Prism = require('prismjs')
     require('prismjs/plugins/autoloader/prism-autoloader')
     Prism.plugins.autoloader.languages_path = `${prismCdn}/components/`
-    require('prismjs/plugins/toolbar/prism-toolbar')
-    require('prismjs/plugins/show-language/prism-show-language')
+    // require('prismjs/plugins/toolbar/prism-toolbar')
+    // require('prismjs/plugins/show-language/prism-show-language')
   }
   loadCss(theme, prismCdn)
   Prism.highlightAllUnder(el)

--- a/src/client/utils/highlight.js
+++ b/src/client/utils/highlight.js
@@ -12,6 +12,8 @@ const renderCode = (el, theme) => {
     Prism = require('prismjs')
     require('prismjs/plugins/autoloader/prism-autoloader')
     Prism.plugins.autoloader.languages_path = `${prismCdn}/components/`
+    require('prismjs/plugins/toolbar/prism-toolbar')
+    require('prismjs/plugins/show-language/prism-show-language')
   }
   loadCss(theme, prismCdn)
   Prism.highlightAllUnder(el)

--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -24,7 +24,11 @@
         :config="config"
         @reply="onReply"
         @load="initComments" />
-      <div class="tk-expand" v-if="showExpand && !loading" @click="onExpand" v-loading="loadingMore">{{ t('COMMENTS_EXPAND') }}</div>
+      <div class="tk-expand-wrap" v-if="showExpand && !loading">
+        <div class="tk-expand" @click="onExpand" v-loading="loadingMore">
+            {{ t('COMMENTS_EXPAND') }}
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tk-submit">
+  <div class="tk-submit" ref="tk-submit">
     <div class="tk-row">
       <tk-avatar :config="config" :mail="mail" />
       <div class="tk-col">
@@ -372,6 +372,12 @@ export default {
     }
   },
   mounted () {
+    if (this.pid) {
+      this.$refs["tk-submit"].scrollIntoView({
+        "behavier": "smooth",
+        "block": "center"
+      })
+    }
     this.initDraft()
     this.initOwo()
     this.addEventListener()


### PR DESCRIPTION
1. 添加单个评论内容的限高
2. 将评论框位置从楼中楼最底调整到评论的下面（感觉更符合评论的逻辑，不然楼中楼太长的情况不会默认跳转而且隔着评论会很难受），并且点击评论图标会跳转到评论的位置
3. 每次评论之后会跳转到新评论的位置
4. 点击折叠的楼中楼中漏出来的评论图标会让已经折叠的楼中楼展开（默认好像是直接截断的），评论结束之后会还原成原来的状态
5. 在折叠打开按钮外面套了一层div,用于用户自己配置按钮+背景渐变效果，或者可以定义为使用黑白主题均适配的背景色（比如按钮的背景色来做？）
例如：
这里的渐变背景比较浅
![image](https://github.com/twikoojs/twikoo/assets/93642775/22872780-dad6-4c1d-95e0-ee4a7d68d1e4)
![image](https://github.com/twikoojs/twikoo/assets/93642775/01e7eb66-432f-48e6-a084-2235c3302d37)

```css
.tk-collapse-wrap, .tk-expand-wrap {
    position: relative;
}
.tk-expand-wrap::after {
    position: absolute;
    z-index: 1;
    display: block;
    overflow: hidden;
    width: 100%;
    content: " ";
    bottom: 0;
    height: 80px;
    background: linear-gradient(180deg, transparent, var(--blur-bg));
    border-radius: 8px;
}
.tk-expand {
    z-index: 2;
    position: absolute;
    left: 50%;
    bottom: 10px;
    text-align: center;
    transform: translate(-50%);
    border: 1px solid var(--block-border);
    border-radius: 6px;
    background: var(--block);
    padding: 1px 20px !important;
    font-size: 15px !important;
    color: var(--text-p3);
    -webkit-user-select: none;
    -moz-user-select: none;
    user-select: none;
    width: fit-content !important;
    line-height: 1.6;
    height: 28px;
    transition: background .5s !important;
}
.tk-collapse-wrap::before {
    position: absolute;
    z-index: 1;
    display: block;
    overflow: hidden;
    width: 100%;
    content: " ";
    bottom: 0;
    height: 100%;
    background: linear-gradient(transparent calc(50% - 1px), var(--block-border) 1px, transparent calc(50%));
}
.tk-expand._collapse {
    bottom: 0;
    position: relative;
}
```