### PR TITLE
docs: improve MongoDB Atlas guide

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -94,33 +94,20 @@ Vercel 部署的环境需配合 1.4.0 以上版本的 twikoo.js 使用
 
 [查看视频教程](https://www.bilibili.com/video/BV1Fh411e7ZH)
 
-1. 申请 [MongoDB](https://www.mongodb.com/cloud/atlas/register) 账号
-2. 创建免费 MongoDB 数据库，区域推荐选择 `AWS / N. Virginia (us-east-1)`
-3. 在 Database Access 页面点击 Add New Database User 创建数据库用户，Authentication Method 选 Password，在 Password Authentication 下设置数据库用户名和密码，用户名和密码可包含数字和大小写字母，请勿包含特殊符号。点击 Database User Privileges 下方的 Add Built In Role，Select Role 选择 Atlas Admin，最后点击 Add User
-
-![](./static/mongodb-1.png)
-
-4. 在 Network Access 页面点击 Add IP Address，Access List Entry 输入 `0.0.0.0/0`（允许所有 IP 地址的连接），点击 Confirm
-
-![](./static/mongodb-2.png)
-
-5. 在 Database 页面点击 Connect，连接方式选择 Drivers，并记录数据库连接字符串，请将连接字符串中的 `<username>:<password>` 修改为刚刚创建的数据库 `用户名:密码`
-
-![](./static/mongodb-3.png)
-
-6. 申请 [Vercel](https://vercel.com/signup) 账号
-7. 点击以下按钮将 Twikoo 一键部署到 Vercel<br>
+1. 申请 [MongoDB Atlas](./mongodb-atlas.md) 账号，获取 MongoDB 连接字符串
+2. 申请 [Vercel](https://vercel.com/signup) 账号
+3. 点击以下按钮将 Twikoo 一键部署到 Vercel<br>
 
 [![Deploy](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/twikoojs/twikoo/tree/main/src/server/vercel-min)
 
-8. 进入 Settings - Environment Variables，添加环境变量 `MONGODB_URI`，值为前面记录的数据库连接字符串
-9. 进入 Settings - Deployment Protection，设置 Vercel Authentication 为 Disabled，并 Save
+4. 进入 Settings - Environment Variables，添加环境变量 `MONGODB_URI`，值为前面记录的数据库连接字符串
+5. 进入 Settings - Deployment Protection，设置 Vercel Authentication 为 Disabled，并 Save
 
 ![](./static/vercel-1.png)
 
-10. 进入 Deployments , 然后在任意一项后面点击更多（三个点） , 然后点击 Redeploy , 最后点击下面的 Redeploy
-11. 进入 Overview，点击 Domains 下方的链接，如果环境配置正确，可以看到 “Twikoo 云函数运行正常” 的提示
-12. Vercel Domains（包含 `https://` 前缀，例如 `https://xxx.vercel.app`）即为您的环境 id
+6. 进入 Deployments , 然后在任意一项后面点击更多（三个点） , 然后点击 Redeploy , 最后点击下面的 Redeploy
+7. 进入 Overview，点击 Domains 下方的链接，如果环境配置正确，可以看到 “Twikoo 云函数运行正常” 的提示
+8. Vercel Domains（包含 `https://` 前缀，例如 `https://xxx.vercel.app`）即为您的环境 id
 
 ## Railway 部署
 
@@ -161,78 +148,52 @@ Netlify 部署的环境需配合 1.4.0 以上版本的 twikoo.js 使用
 Netlify 免费等级（Functions Level 0）支持每月 125,000 请求次数和 100 小时函数计算时长
 :::
 
-1. 申请 [MongoDB](https://www.mongodb.com/cloud/atlas/register) 账号
-2. 创建免费 MongoDB 数据库，区域推荐选择 `AWS / N. Virginia (us-east-1)`
-3. 在 Database Access 页面点击 Add New Database User 创建数据库用户，Authentication Method 选 Password，在 Password Authentication 下设置数据库用户名和密码，用户名和密码可包含数字和大小写字母，请勿包含特殊符号。点击 Database User Privileges 下方的 Add Built In Role，Select Role 选择 Atlas Admin，最后点击 Add User
-
-![](./static/mongodb-1.png)
-
-4. 在 Network Access 页面点击 Add IP Address，Access List Entry 输入 `0.0.0.0/0`（允许所有 IP 地址的连接），点击 Confirm
-
-![](./static/mongodb-2.png)
-
-5. 在 Database 页面点击 Connect，连接方式选择 Drivers，并记录数据库连接字符串，请将连接字符串中的 `<username>:<password>` 修改为刚刚创建的数据库 `用户名:密码`
-
-![](./static/mongodb-3.png)
-
-6. 申请并登录 [Netlify](https://app.netlify.com) 账号，创建一个 Team
-7. 打开 [twikoojs/twikoo-netlify](https://github.com/twikoojs/twikoo-netlify) 点击 fork 将仓库 fork 到自己的账号下
-8. 回到 Netlify，点击 Add new site - Import an existing project
+1. 申请 [MongoDB Atlas](./mongodb-atlas.md) 账号，获取 MongoDB 连接字符串
+2. 申请并登录 [Netlify](https://app.netlify.com) 账号，创建一个 Team
+3. 打开 [twikoojs/twikoo-netlify](https://github.com/twikoojs/twikoo-netlify) 点击 fork 将仓库 fork 到自己的账号下
+4. 回到 Netlify，点击 Add new site - Import an existing project
 
 ![](./static/netlify-1.png)
 
-9. 点击 Deploy with GitHub，如果未授权 GitHub 账号，先授权，然后选择前面 fork 的 twikoo-netlify 项目
+5. 点击 Deploy with GitHub，如果未授权 GitHub 账号，先授权，然后选择前面 fork 的 twikoo-netlify 项目
 
 ![](./static/netlify-2.png)
 
-10. 点击 Add environment variables - New variable，Key 输入 `MONGODB_URI`，Value 输入前面记录的数据库连接字符串，点击 Deploy twikoo-netlify
+6. 点击 Add environment variables - New variable，Key 输入 `MONGODB_URI`，Value 输入前面记录的数据库连接字符串，点击 Deploy twikoo-netlify
 
 ![](./static/netlify-3.png)
 
-11. 部署完成后，点击 Domain settings - 右侧 Options - Edit site name，可以设置属于自己的三级域名（`https://xxx.netlify.app`）
+7. 部署完成后，点击 Domain settings - 右侧 Options - Edit site name，可以设置属于自己的三级域名（`https://xxx.netlify.app`）
 
 ![](./static/netlify-4.png)
 
-12. 进入 Site overview，点击上方的链接，如果环境配置正确，可以看到 “Twikoo 云函数运行正常” 的提示
+8. 进入 Site overview，点击上方的链接，如果环境配置正确，可以看到 “Twikoo 云函数运行正常” 的提示
 
 ![](./static/netlify-5.png)
 
-13. 云函数地址（包含 `https://` 前缀和 `/.netlify/functions/twikoo` 后缀，例如 `https://xxx.netlify.app/.netlify/functions/twikoo`）即为您的环境 id
+9. 云函数地址（包含 `https://` 前缀和 `/.netlify/functions/twikoo` 后缀，例如 `https://xxx.netlify.app/.netlify/functions/twikoo`）即为您的环境 id
 
 ## Hugging Face 部署
 
-1. 申请 [MongoDB](https://www.mongodb.com/cloud/atlas/register) 账号
-2. 创建免费 MongoDB 数据库
-3. 在 Database Access 页面点击 Add New Database User 创建数据库用户，Authentication Method 选 Password，在 Password Authentication 下设置数据库用户名和密码，用户名和密码可包含数字和大小写字母，请勿包含特殊符号。点击 Database User Privileges 下方的 Add Built In Role，Select Role 选择 Atlas Admin，最后点击 Add User
-
-![](./static/mongodb-1.png)
-
-4. 在 Network Access 页面点击 Add IP Address，Access List Entry 输入 `0.0.0.0/0`（允许所有 IP 地址的连接），点击 Confirm
-
-![](./static/mongodb-2.png)
-
-5. 在 Database 页面点击 Connect，连接方式选择 Drivers，并记录数据库连接字符串，请将连接字符串中的 `<username>:<password>` 修改为刚刚创建的数据库 `用户名:密码`
-
-![](./static/mongodb-3.png)
-
-6. 申请 [Hugging Face](https://huggingface.co/join) 账号
-7. 登录，点击 Spaces - Create new Space
+1. 申请 [MongoDB Atlas](./mongodb-atlas.md) 账号，获取 MongoDB 连接字符串
+2. 申请 [Hugging Face](https://huggingface.co/join) 账号
+3. 登录，点击 Spaces - Create new Space
 
 ![](./static/hugging-1.png)
 
-8. 输入 Space name，Select the Space SDK 选择 Docker，Choose a Docker template 选择 Blank，Space hardware 选择 FREE，选择 Public，点击 Create Space
+4. 输入 Space name，Select the Space SDK 选择 Docker，Choose a Docker template 选择 Blank，Space hardware 选择 FREE，选择 Public，点击 Create Space
 
 ![](./static/hugging-2.png)
 
-9. 进入刚刚创建的 Space，点击页面上方的 Settings，滚动到 Variables and secrets 部分，点击 New secret，Name 输入 `MONGODB_URI`，Value 输入前面记录的数据库连接字符串，点击 Save
+5. 进入刚刚创建的 Space，点击页面上方的 Settings，滚动到 Variables and secrets 部分，点击 New secret，Name 输入 `MONGODB_URI`，Value 输入前面记录的数据库连接字符串，点击 Save
 
 ![](./static/hugging-3.png)
 
-10. 点击页面上方的 Files - Add file - Create a new file
+6. 点击页面上方的 Files - Add file - Create a new file
 
 ![](./static/hugging-4.png)
 
-11. 在 Name your file 中输入 `Dockerfile`，在 Edit 区域输入以下内容
+7. 在 Name your file 中输入 `Dockerfile`，在 Edit 区域输入以下内容
 
 ```Dockerfile
 FROM imaegoo/twikoo
@@ -242,14 +203,15 @@ EXPOSE 7860
 
 ![](./static/hugging-5.png)
 
-12. 点击 Commit new file to main
-13. 点击右上角 Settings 右方的菜单（三个点）图标 - Embed this Space，Direct URL 下的内容（例如 `https://xxx-xxx.hf.space`）即为您的环境 id
+8. 点击 Commit new file to main
+9. 点击右上角 Settings 右方的菜单（三个点）图标 - Embed this Space，Direct URL 下的内容（例如 `https://xxx-xxx.hf.space`）即为您的环境 id
 
 ![](./static/hugging-6.png)
 
 ## AWS Lambda 部署
 
 1. 注册 AWS 账号并配置 Terraform CLI。
+2. 如需使用托管的 MongoDB 数据库，可申请 [MongoDB Atlas](./mongodb-atlas.md) 账号。
 2. 参考 `src/server/aws-lambda/terraform` 目录中 Terraform 代码创建 AWS 资源。
 3. 部署完成后，Terraform 会将 `lambda_function_url` 打印在屏幕上，您也可以使用 `terraform output` 获取这一 URL，如：
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -212,8 +212,8 @@ EXPOSE 7860
 
 1. 注册 AWS 账号并配置 Terraform CLI。
 2. 如需使用托管的 MongoDB 数据库，可申请 [MongoDB Atlas](./mongodb-atlas.md) 账号。
-2. 参考 `src/server/aws-lambda/terraform` 目录中 Terraform 代码创建 AWS 资源。
-3. 部署完成后，Terraform 会将 `lambda_function_url` 打印在屏幕上，您也可以使用 `terraform output` 获取这一 URL，如：
+3. 参考 `src/server/aws-lambda/terraform` 目录中 Terraform 代码创建 AWS 资源。
+4. 部署完成后，Terraform 会将 `lambda_function_url` 打印在屏幕上，您也可以使用 `terraform output` 获取这一 URL，如：
 
 ```
 $ terraform output

--- a/docs/mongodb-atlas.md
+++ b/docs/mongodb-atlas.md
@@ -3,7 +3,7 @@
 MongoDB Atlas 是 MongoDB Inc 提供的 MongoDB 数据库托管服务。免费账户可以永久使用 500 MiB 的数据库，足够存储 Twikoo 评论使用。
 
 1. 申请 [MongoDB AtLas](https://www.mongodb.com/cloud/atlas/register) 账号
-2. 创建免费 MongoDB 数据库，区域推荐选择 `AWS / Oregon (us-west-2)`，该数据中心基建成熟，故障率低，且使用 Oregon 州的清洁能源，较为环保
+2. 创建免费 MongoDB 数据库，区域推荐选择离 Twikoo 后端（Vercel / Netlify / AWS Lambda / VPS）地理位置较近的数据中心以获得更低的数据库连接延迟。如果不清楚自己的后端在哪个区域，也可选择 `AWS / Oregon (us-west-2)`，该数据中心基建成熟，故障率低，且使用 Oregon 州的清洁能源，较为环保
 3. 在 Database Access 页面点击 Add New Database User 创建数据库用户，Authentication Method 选 Password，在 Password Authentication 下设置数据库用户名和密码，建议点击 Auto Generate 自动生成一个不含特殊符号的强壮密码并妥善保存。点击 Database User Privileges 下方的 Add Built In Role，Select Role 选择 Atlas Admin，最后点击 Add User
 
 ![](./static/mongodb-1.png)

--- a/docs/mongodb-atlas.md
+++ b/docs/mongodb-atlas.md
@@ -1,0 +1,21 @@
+# MongoDB Atlas
+
+MongoDB Atlas 是 MongoDB Inc 提供的 MongoDB 数据库托管服务。免费账户可以永久使用 500 MiB 的数据库，足够存储 Twikoo 评论使用。
+
+1. 申请 [MongoDB AtLas](https://www.mongodb.com/cloud/atlas/register) 账号
+2. 创建免费 MongoDB 数据库，区域推荐选择 `AWS / Oregon (us-west-2)`，该数据中心基建成熟，故障率低，且使用 Oregon 州的清洁能源，较为环保
+3. 在 Database Access 页面点击 Add New Database User 创建数据库用户，Authentication Method 选 Password，在 Password Authentication 下设置数据库用户名和密码，建议点击 Auto Generate 自动生成一个不含特殊符号的强壮密码并妥善保存。点击 Database User Privileges 下方的 Add Built In Role，Select Role 选择 Atlas Admin，最后点击 Add User
+
+![](./static/mongodb-1.png)
+
+4. 在 Network Access 页面点击 Add IP Address 添加网络白名单。因为 Vercel / Netlify / Lambda 的出口地址不固定，因此 Access List Entry 输入 `0.0.0.0/0`（允许所有 IP 地址的连接）即可。如果 Twikoo 部署在自己的服务器上，这里可以填入固定 IP 地址。点击 Confirm 保存
+
+![](./static/mongodb-2.png)
+
+5. 在 Database 页面点击 Connect，连接方式选择 Drivers，并记录数据库连接字符串，请将连接字符串中的 `<username>:<password>` 修改为刚刚创建的数据库 `用户名:密码`
+
+![](./static/mongodb-3.png)
+
+6. （可选）默认的连接字符串没有指定数据库名称，Twikoo 会连接到默认的名为 `test` 的数据库。如果需要在同一个 MongoDB 里运行其他业务或供多个 Twikoo 实例使用，建立加入数据库名称并配置对应的 ACL。
+
+连接字符串包含了连接到 MongoDB 数据库的所有信息，一旦泄露会导致评论被任何人添加、修改、删除，并有可能获取你的 SMTP、图床 token 等信息。请妥善记录这一字符串，之后需要填入到 Twikoo 的部署平台里。


### PR DESCRIPTION
本 PR 对 MongoDB Atlas 账号的申请进行了扩充，增加了有关数据中心选择、IP 白名单、连接字符串的处理的最佳实践，并且将整个章节挪到一个单独的页面，方便多个部署方式引用。
