### PR TITLE
Increase AWS Lambda Timeout

### DIFF
--- a/src/server/aws-lambda/terraform/main.tf
+++ b/src/server/aws-lambda/terraform/main.tf
@@ -18,7 +18,7 @@ module "lambda_function" {
   function_name = "twikoo"
   handler       = "index.handler"
   runtime       = "nodejs20.x"
-  timeout       = 10
+  timeout       = 60
 
   source_path = "../src"
 


### PR DESCRIPTION
10 seconds are not enough to upload images in comments, so increase the timeout to 60 seconds.

现在default timeout是10秒，对于基础的API已经满足，但是如果在评论区上传图片会导致timeout，所以将timeout增加到60秒以支持上传图片。