### PR TITLE
chore(Dockerfile): Use Alpine image for smaller size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG NODE_IMAGE=node
 FROM ${NODE_IMAGE}:lts AS build
 WORKDIR /app
-ENV NODE_ENV production
+ENV NODE_ENV=production
 RUN set -eux; \
   npm install --production tkserver@latest; \
   mkdir -p data
-FROM ${NODE_IMAGE}:lts-buster-slim
+FROM ${NODE_IMAGE}:lts-alpine
 WORKDIR /app
-ENV NODE_ENV production
+ENV NODE_ENV=production
 COPY --from=build /app .
 EXPOSE 8080
 CMD ["/app/node_modules/.bin/tkserver"]


### PR DESCRIPTION
使用`lts-alpine`能够减小构建出的image体积（本地测试从325MB缩小为了264MB，约60MB）。经过简单的测试，评论、邮件通知、实时通知、导入导出功能均正常。

同时修复了构建镜像时的警告`"ENV key=value" should be used instead of legacy "ENV key value" format`。