### PR TITLE
解决 vercel 部署中，设置自定义域名后，即时通知发送失败 401 错误问题

### DIFF
--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -614,9 +614,8 @@ async function commentSubmit (event, request) {
   try {
     logger.log('开始异步垃圾检测、发送评论通知')
     logger.log('POST_SUBMIT')
-    const baseUrl = process.env.CUSTOM_DOMAIN ? `https://${process.env.CUSTOM_DOMAIN}` : `https://${request.headers.host}`
     await Promise.race([
-      axios.post(baseUrl, {
+      axios.post(`https://${process.env.CUSTOM_DOMAIN}`, {
         event: 'POST_SUBMIT',
         comment
       }, { headers: { 'x-twikoo-recursion': config.ADMIN_PASS || 'true' } }),

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -614,8 +614,9 @@ async function commentSubmit (event, request) {
   try {
     logger.log('开始异步垃圾检测、发送评论通知')
     logger.log('POST_SUBMIT')
+    const baseUrl = process.env.CUSTOM_DOMAIN ? `https://${process.env.CUSTOM_DOMAIN}` : `https://${request.headers.host}`
     await Promise.race([
-      axios.post(`https://${process.env.VERCEL_URL}`, {
+      axios.post(baseUrl, {
         event: 'POST_SUBMIT',
         comment
       }, { headers: { 'x-twikoo-recursion': config.ADMIN_PASS || 'true' } }),


### PR DESCRIPTION
原代码逻辑：  
```js
    await Promise.race([
      axios.post(`https://${process.env.VERCEL_URL}`, {
        event: 'POST_SUBMIT',
        comment
      }, { headers: { 'x-twikoo-recursion': config.ADMIN_PASS || 'true' } }),
      // 如果超过 5 秒还没收到异步返回，直接继续，减少用户等待的时间
      new Promise((resolve) => setTimeout(resolve, 5000))
    ])
```
`process.env.VERCEL_URL` 是自动分配的访问地址，配置自定义域名后就不一致了。  
  
本改动需新增环境变量 `CUSTOM_DOMAIN` 配置自己的自定义域名，如：`twikoo.guole.fun`