### PR TITLE
添加对EasyImage2.0图床的支持

### DIFF
--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -91,12 +91,14 @@ const imageBedServices = [
   '7bu (https://7bu.top)',
   'smms (https://sm.ms)',
   'lskypro',
-  'piclist'
+  'piclist',
+  'easyimage'
 ].map(s => `"${s}"`)
 
 const customImageBedServices = [
   'lskypro',
-  'piclist'
+  'piclist',
+  'easyimage'
 ].map(s => `"${s}"`)
 
 const defaultGravatar = [

--- a/src/server/function/twikoo/utils/image.js
+++ b/src/server/function/twikoo/utils/image.js
@@ -137,7 +137,7 @@ const fn = {
       res.data = {
         url: response.url,
         thumb: response.thumb, // 可选返回缩略图
-        del: response.del      // 可选返回删除链接
+        del: response.del // 可选返回删除链接
       }
     } catch (e) {
       let errorMsg = `EasyImage2.0 上传失败: ${e.message}`

--- a/src/server/function/twikoo/utils/image.js
+++ b/src/server/function/twikoo/utils/image.js
@@ -27,6 +27,8 @@ const fn = {
         await fn.uploadImageToLskyPro({ photo, fileName, config, res, imageCdn: config.IMAGE_CDN_URL })
       } else if (config.IMAGE_CDN === 'piclist') {
         await fn.uploadImageToPicList({ photo, fileName, config, res, imageCdn: config.IMAGE_CDN_URL })
+      } else if (config.IMAGE_CDN === 'easyimage') {
+        await fn.uploadImageToEasyImage({ photo, fileName, config, res })
       } else {
         throw new Error('不支持的图片上传服务')
       }
@@ -94,6 +96,56 @@ const fn = {
       res.data.url = uploadResult.data.result[0]
     } else {
       throw new Error(uploadResult.data.message)
+    }
+  },
+  async uploadImageToEasyImage ({ photo, fileName, config, res }) {
+    // EasyImage2.0 https://github.com/icret/EasyImages2.0 简单图床 - 一款功能强大无数据库的图床 2.0版
+    try {
+      // 参数校验
+      if (!config.IMAGE_CDN_URL) {
+        throw new Error('未配置 EasyImage2.0 的 API 地址 (IMAGE_CDN_URL)')
+      }
+      if (!config.IMAGE_CDN_TOKEN) {
+        throw new Error('未配置 EasyImage2.0 的 Token (IMAGE_CDN_TOKEN)')
+      }
+      // 构建固定格式的 FormData
+      const formData = new FormData()
+      // 添加 token 参数到 Body
+      formData.append('token', config.IMAGE_CDN_TOKEN)
+      // 添加图片文件（固定参数名 image）
+      formData.append('image', fn.base64UrlToReadStream(photo, fileName), {
+        filename: fileName
+      })
+      // 发送请求
+      const uploadResult = await axios.post(config.IMAGE_CDN_URL, formData, {
+        headers: {
+          ...formData.getHeaders(),
+          'User-Agent': 'Twikoo'
+        }
+      })
+      // 解析响应
+      const response = uploadResult.data
+      // 检查业务状态码
+      if (response.code !== 200 || response.result !== 'success') {
+        throw new Error(`API 返回错误 (CODE: ${response.code})`)
+      }
+      // 提取图片 URL（固定 JSON 路径 url）
+      if (!response.url) {
+        throw new Error('未找到有效图片 URL')
+      }
+      // 返回标准化结构
+      res.data = {
+        url: response.url,
+        thumb: response.thumb, // 可选返回缩略图
+        del: response.del      // 可选返回删除链接
+      }
+    } catch (e) {
+      let errorMsg = `EasyImage2.0 上传失败: ${e.message}`
+      // 追加 API 返回的错误详情
+      if (e.response?.data) {
+        errorMsg += ` | 错误类型: ${e.response.data.message || '未知'}`
+      }
+      throw new Error(errorMsg)
     }
   },
   base64UrlToReadStream (base64Url, fileName) {


### PR DESCRIPTION
添加对 EasyImage2.0 简单图床的支持

简单图床 - 一款功能强大无数据库的图床 2.0版

Github：https://github.com/icret/EasyImages2.0

文档：https://icret.github.io/EasyImages2.0/#/

IMAGE_CDN_URL处填写网站的API调用地址，例如：https://img.example.com/api/index.php

IMAGE_CDN_TOKEN处填写网站生成的Token，例如：1c17b11693cb5ec63859b091c5b9c1b2

配置面板：

![1](https://github.com/user-attachments/assets/e2a3ec57-741b-44c2-8f1c-f4e38744a2c2)