### PR TITLE
feat: 更新头像参数

### DIFF
--- a/src/client/view/components/TkAvatar.vue
+++ b/src/client/view/components/TkAvatar.vue
@@ -37,7 +37,7 @@ export default {
         return this.config.DEFAULT_GRAVATAR
       }
       if (this.gravatarCdn === 'weavatar.com') {
-        return `letter&letter=${this.nick.charAt(0)}`
+        return `initials&name=${this.nick.charAt(0)}`
       }
       return 'identicon'
     },

--- a/src/client/view/components/TkAvatar.vue
+++ b/src/client/view/components/TkAvatar.vue
@@ -36,10 +36,7 @@ export default {
       if (this.config && this.config.DEFAULT_GRAVATAR) {
         return this.config.DEFAULT_GRAVATAR
       }
-      if (this.gravatarCdn === 'weavatar.com') {
-        return `initials&name=${this.nick.charAt(0)}`
-      }
-      return 'identicon'
+      return 'initials&name=${this.nick.charAt(0)}'
     },
     avatarInner () {
       if (this.avatar) {

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -214,7 +214,7 @@ const fn = {
       return comment.avatar
     } else {
       const gravatarCdn = config.GRAVATAR_CDN || 'weavatar.com'
-      let defaultGravatar = gravatarCdn === 'weavatar.com' ? `initials&name=${comment.nick.charAt(0)}` : 'identicon'
+      let defaultGravatar = `initials&name=${comment.nick.charAt(0)}`
       if (config.DEFAULT_GRAVATAR) {
         defaultGravatar = config.DEFAULT_GRAVATAR
       }

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -214,7 +214,7 @@ const fn = {
       return comment.avatar
     } else {
       const gravatarCdn = config.GRAVATAR_CDN || 'weavatar.com'
-      let defaultGravatar = gravatarCdn === 'weavatar.com' ? `letter&letter=${comment.nick.charAt(0)}` : 'identicon'
+      let defaultGravatar = gravatarCdn === 'weavatar.com' ? `initials&name=${comment.nick.charAt(0)}` : 'identicon'
       if (config.DEFAULT_GRAVATAR) {
         defaultGravatar = config.DEFAULT_GRAVATAR
       }


### PR DESCRIPTION
Gravatar 今年初已支持首字母头像，因此需要同步调整参数（WeAvatar 已兼容更新后的参数，旧参数将于明年初下线）。

见：https://blog.gravatar.com/2025/02/19/initials-avatars-email-signatures/