### PR TITLE
fix(avatar): template literals occurred in url

### DIFF
--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -442,13 +442,13 @@ export default {
     '댓글 서버 접근 허용 웹사이트 주소. 참고: 등록된 웹사이트만 댓글 시스템과 안전하게 통신합니다. 주소 오류 시 댓글창이 사라질 수 있습니다. 기본값: 비어 있음(보안 취약), 형식: https://blog.example.com; 여러 주소는 쉼표(,)로 구분.'
   ],
   [S.ACI + '_DEFAULT_GRAVATAR']: [
-    `默认的头像显示。默认值为 "identicon"，可选：${defaultGravatar.join('、')}`,
-    `預設的頭像顯示。預設值為 "identicon"，可選：${defaultGravatar.join('、')}`,
-    `預設的大頭貼照圖示。預設值為 "identicon"，選項：${defaultGravatar.join('、')}`,
-    `Avatar placeholder. Default:  "identicon". Choose from: ${defaultGravatar.join(', ')}`,
-    `Аватар тўлдирувчиси. Стандарт: «идентификатор». Қуйидагилардан танланг: ${defaultGravatar.join(', ')}`,
-    `デフォルトのプロフィール画像表示。デフォルトは "identicon" で、選択肢は：${defaultGravatar.join('、')} です`,
-    `프로필 기본 이미지. 기본값: "identicon". 사용 가능 스타일: ${defaultGravatar.join(', ')}`
+    `默认的头像显示。默认值（留空）为 "initials"，可选：${defaultGravatar.join('、')}`,
+    `預設的頭像顯示。預設值（留空）為 "initials"，可選：${defaultGravatar.join('、')}`,
+    `預設的大頭貼照圖示。預設值（留空）為 "initials"，選項：${defaultGravatar.join('、')}`,
+    `Avatar placeholder. Default (when empty): "initials". Choose from: ${defaultGravatar.join(', ')}`,
+    `Аватар тўлдирувчиси. Стандарт (агар бўш қолдирилса): «идентификатор». Қуйидагилардан танланг: ${defaultGravatar.join(', ')}`,
+    `デフォルトのプロフィール画像表示。デフォルト（空欄時）は "initials" で、選択肢は：${defaultGravatar.join('、')} です`,
+    `프로필 기본 이미지. 기본값(비워둘 경우): "initials". 사용 가능 스타일: ${defaultGravatar.join(', ')}`
   ],
   [S.ACI + '_EMOTION_CDN']: [
     '表情 CDN，英文逗号分隔。默认为：https://owo.imaegoo.com/owo.json',

--- a/src/client/view/components/TkAvatar.vue
+++ b/src/client/view/components/TkAvatar.vue
@@ -36,7 +36,7 @@ export default {
       if (this.config && this.config.DEFAULT_GRAVATAR) {
         return this.config.DEFAULT_GRAVATAR
       }
-      return `initials&name=${this.nick.charAt(0)}`
+      return `initials&name=${this.nick}`
     },
     avatarInner () {
       if (this.avatar) {

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -214,7 +214,7 @@ const fn = {
       return comment.avatar
     } else {
       const gravatarCdn = config.GRAVATAR_CDN || 'weavatar.com'
-      let defaultGravatar = `initials&name=${comment.nick.charAt(0)}`
+      let defaultGravatar = `initials&name=${comment.nick}`
       if (config.DEFAULT_GRAVATAR) {
         defaultGravatar = config.DEFAULT_GRAVATAR
       }


### PR DESCRIPTION
## 问题描述

在 PR #810 中引入了新的默认 Gravatar 头像 `initials&name=${this.nick.charAt(0)}`（对应版本号 1.6.43），但导致了前端的头像链接直接变成了字符串模板。

根据 Gravatar 官方的文档可以看到当设置 `d=initials` 的时候有两个选项，其中的 `name` 选项会由 Gravatar 自动摘取给定 name 中对应的 Initials，无需请求方处理。（同样的，weavatar 也兼容这个行为）

## 代码变更

这个 PR 主要更改了 2 处内容：

1. 移除 `.charAt(0)` 方法，这个方法会在 `this.nick` 的值为 `undefined` 的时候抛出异常 `TypeError`。但在模板字符串中的时候值为 undefined 不会抛出异常。
2. 更新前端管理面板的 `_DEFAULT_GRAVATAR` 设置的提示文本，将 `identicon` 更改为 `initials`，并新增提示 `（留空）` 提示用户在这个值为空的时候对应的行为。

## 参考

[直接链接到官方文档具体的位置](https://docs.gravatar.com/sdk/images/#:~:text=name%20%E2%80%93%20pass%20the%20name%20and%20have%20the%20initials%20be%20extracted)

下面是在 [https://twikoo.js.org/](https://twikoo.js.org/) 主页下方评论区的截图。

![image](https://github.com/user-attachments/assets/70daadc7-18bc-43b9-b47b-c790fbb720cf)

![image](https://github.com/user-attachments/assets/d7ede8c7-c174-4f6e-9325-cae5aaead0e1)
