### PR TITLE
bump aws-lambda nodejs runtime to 24.x

### DIFF
--- a/src/server/aws-lambda/terraform/main.tf
+++ b/src/server/aws-lambda/terraform/main.tf
@@ -17,7 +17,7 @@ module "lambda_function" {
 
   function_name = "twikoo"
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   timeout       = 60
 
   source_path = "../src"


### PR DESCRIPTION
We are contacting you as we have identified that your AWS Account currently has one or more AWS Lambda functions using the Node.js 20.x runtime.

We are ending support for Node.js 20.x in Lambda on April 30, 2026. This follows Node.js 20.x End-Of-Life (EOL) scheduled on April 30, 2026 [1]. End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.