### PR TITLE
feat: add Chevereto image hosting support

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -124,6 +124,29 @@ The Tencent Cloud environment comes with cloud storage, so you can upload images
 | 7bu | https://7bu.top | Go to No Bed, powered by 杜老师, no free packages |
 | smms | https://sm.ms | SMMS image bed, there is a free package, please register your account, `IMAGE_CDN_TOKEN` can be obtained in [Dashboard](https://sm.ms/home/apitoken) |
 | [lsky-pro](https://www.lsky.pro) | Private Deployment | LankenGraphics 2.0 version, `IMAGE_CDN` please configure the URL address of the home page of the graph bed (such as `https://7bu.top`), `IMAGE_CDN_TOKEN` get way please refer to the tutorial [杜老师 said the graph bed: new version Go not to the bed Token acquisition and emptying](https://dusays.com/454/), the format of the obtained token should be `1\|1bJbwlqBfnggmOMEZqXT5XusaIwqiZjCDs7r1Ob5`) |
+| [PicList](https://piclist.cn/) | Self-hosted | Set `IMAGE_CDN_URL` to the service URL. For `IMAGE_CDN_TOKEN`, see [PicList docs: API Authentication](https://piclist.cn/advanced.html#%E6%8E%A5%E5%8F%A3%E9%89%B4%E6%9D%83) |
+| [EasyImage2.0](https://github.com/icret/EasyImages2.0) | Self-hosted | Set `IMAGE_CDN_URL` to the API URL and `IMAGE_CDN_TOKEN` to your token |
+| [Chevereto](https://chevereto.com) | Self-hosted | Set `IMAGE_CDN_URL` to your Chevereto site (e.g. `https://your-chevereto.com`) and `IMAGE_CDN_TOKEN` to your API Key (found in Dashboard → Settings → API). Requires a paid Chevereto license or a fork that supports API v1 |
+
+## Can self-hosted deployments connect to an external database?
+
+By default, Twikoo's self-hosted version uses LokiJS, a built-in database with a capacity of approximately 1 GB. No external database is required. Data is stored in a `data` directory relative to where Twikoo was started; you can back it up by simply copying that directory.
+
+If you have a MongoDB instance, you can use it as an external database by setting the environment variable `MONGODB_URI` to your connection string, for example: `mongodb://<username>:<password>@<host>/`.
+
+## Comment submission fails with error 0 and the admin panel is inaccessible?
+
+On a page with the comment box, open your browser's developer tools (F12 on Windows), go to the **Console** tab, and look for errors containing the keyword `twikoo`.
+
+**ERR_BLOCKED_BY_CLIENT** — Disable your ad blocker or whitelist the current site, then refresh.
+
+**ERR_CONNECTION_CLOSED / ERR_CONNECTION_TIMED_OUT / ERR_CONNECTION_RESET** — Check whether your network can reach the cloud function. Some regions cannot access Vercel or similar services; try a different deployment method.
+
+**`Access to XMLHttpRequest at 'https://tcb-api.tencentcloudapi.com/web?env=...' has been blocked by CORS policy`** — Make sure your frontend JS is up to date and that `envId` starts with `https://`.
+
+**`No 'Access-Control-Allow-Origin' header is present`** — Visit your `envId` URL directly to check whether the cloud function is running. If not, redeploy it carefully. If it is running, start the site on localhost, go to **Admin Panel → Configuration → General**, clear the `CORS_ALLOW_ORIGIN` field, save, and refresh.
+
+For any other error, please [open an issue](https://github.com/twikoojs/twikoo/issues/new) and include the full error message.
 
 ## Can it be deployed privately?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -129,6 +129,7 @@ Akismet (Automattic Kismet) 是应用广泛的一个垃圾留言过滤系统，�
 | [lsky-pro](https://www.lsky.pro) | 私有部署 | 兰空图床 2.0 版本，`IMAGE_CDN` 请配置图床首页 URL 地址（如 `https://7bu.top`），`IMAGE_CDN_TOKEN` 获取方式请参考教程 [杜老师说图床：新版本去不图床 Token 的获取与清空](https://dusays.com/454/)，获取到的 token 格式应为 `1\|1bJbwlqBfnggmOMEZqXT5XusaIwqiZjCDs7r1Ob5`） |
 | [PicList](https://piclist.cn/)                         | 私有部署        | `IMAGE_CDN_URL` 配置图床 URL 地址，`IMAGE_CDN_TOKEN`填写参考[piclist文档：接口鉴权](https://piclist.cn/advanced.html#%E6%8E%A5%E5%8F%A3%E9%89%B4%E6%9D%83) |
 | [EasyImage2.0](https://github.com/icret/EasyImages2.0) | 私有部署        | `IMAGE_CDN_URL` 配置图床 URL 地址，`IMAGE_CDN_TOKEN`填写 TOKEN |
+| [Chevereto](https://chevereto.com) | 私有部署 | cheverto v4版本,`IMAGE_CDN_URL` 配置图床 URL 地址（如 `https://your-chevereto.com`），`IMAGE_CDN_TOKEN` 填写 API Key（在管理后台 Dashboard → Settings → API 中获取）。注意：需要支持 API v1 的 Chevereto 实例 |
 
 ## 私有部署能连接自己的数据库吗？
 

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -92,7 +92,8 @@ const imageBedServices = [
   'smms (https://sm.ms)',
   'lskypro',
   'piclist',
-  'easyimage'
+  'easyimage',
+  'chevereto'
 ].map(s => `"${s}"`)
 
 const customImageBedServices = [


### PR DESCRIPTION
feat: 增加 Chevereto 图床支持

- 在 src/server/function/twikoo/utils/image.js 中添加 uploadImageToChevereto 方法
- 更新 docs/faq.md 和 docs/en/faq.md 中的图床表格
- 新增配置项：IMAGE_CDN=chevereto, IMAGE_CDN_URL, IMAGE_CDN_TOKEN
- 英文版补全的缺失内容：
  - 「私有部署能连接自己的数据库吗」章节 → Can self-hosted deployments connect to an external database?
  - 「部署后遇到评论失败: 0」章节 → Comment submission fails with error 0
  - 图床表格补齐 PicList、EasyImage2.0 两行