### PR TITLE
feat: 将评论排序切换为并排文字选项

### DIFF
--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -9,11 +9,21 @@
         </span>
         <span>
           <span class="tk-comments-sort" v-if="!loading && comments.length && config.SHOW_ORDER !== 'false'">
-            <select v-model="currentSort" @change="onSortChange" class="tk-sort-select">
-              <option value="newest">{{ t('COMMENTS_SORT_NEWEST') }}</option>
-              <option value="oldest">{{ t('COMMENTS_SORT_OLDEST') }}</option>
-              <option value="popular">{{ t('COMMENTS_SORT_POPULAR') }}</option>
-            </select>
+            <button
+              class="tk-sort-item"
+              type="button"
+              :class="{ __active: currentSort === 'newest' }"
+              @click="setSort('newest')">{{ t('COMMENTS_SORT_NEWEST') }}</button>
+            <button
+              class="tk-sort-item"
+              type="button"
+              :class="{ __active: currentSort === 'oldest' }"
+              @click="setSort('oldest')">{{ t('COMMENTS_SORT_OLDEST') }}</button>
+            <button
+              class="tk-sort-item"
+              type="button"
+              :class="{ __active: currentSort === 'popular' }"
+              @click="setSort('popular')">{{ t('COMMENTS_SORT_POPULAR') }}</button>
           </span>
           <span class="tk-icon __comments" v-if="!loading && !loadingMore" v-html="iconRefresh" @click="refresh"
             ></span><span class="tk-icon __comments" v-if="showAdminEntry" v-html="iconSetting" @click="openAdmin"
@@ -89,7 +99,9 @@ export default {
       this.comments = []
       this.initComments()
     },
-    onSortChange () {
+    setSort (sort) {
+      if (this.currentSort === sort) return
+      this.currentSort = sort
       this.comments = []
       this.initComments()
     },
@@ -167,20 +179,23 @@ export default {
 .tk-comments-sort {
   display: inline-flex;
   align-items: center;
+  gap: 0.75em;
   margin-right: 0.5em;
 }
-.tk-sort-select {
+.tk-sort-item {
   font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid #ddd;
-  border-radius: 0.25rem;
-  background: white;
+  padding: 0;
+  border: 0;
+  background: transparent;
   cursor: pointer;
+  color: rgba(64, 158, 255, 0.6);
+}
+.tk-sort-item.__active {
   color: #409eff;
 }
-.tk-sort-select:focus {
+.tk-sort-item:focus {
   outline: none;
-  border-color: #409eff;
+  color: #409eff;
 }
 .tk-icon.__comments {
   display: inline-flex;


### PR DESCRIPTION
原来的下拉框在视觉上总感觉格格不入，因为上面有两个很大的预览和发送按钮了，下面加一个同样大小的下拉框，而右侧又是小小的刷新图标，太突兀了

所以将评论排序选项改为并排文字选项，这样感觉比下拉选项框更统一美观，也和右侧的刷新和管理按钮图标更一致


<img width="1399" height="365" alt="图片" src="https://github.com/user-attachments/assets/856f68d3-10b7-49eb-b5ac-75cfff79a3db" />
