### PR TITLE
feat: Add nofollow and ugc to external links

### DIFF
--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -150,7 +150,7 @@ const renderLinks = (el) => {
   }
   for (const aEl of aEls) {
     aEl.setAttribute('target', '_blank')
-    aEl.setAttribute('rel', 'noopener noreferrer')
+    aEl.setAttribute('rel', 'noopener noreferrer nofollow ugc')
   }
 }
 

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -9,7 +9,7 @@
       <div class="tk-row">
         <div class="tk-meta">
           <strong class="tk-nick" v-if="!convertedLink">{{ comment.nick }}</strong>
-          <a class="tk-nick tk-nick-link" v-if="convertedLink" :href="convertedLink" target="_blank" rel="noopener noreferrer">
+          <a class="tk-nick tk-nick-link" v-if="convertedLink" :href="convertedLink" target="_blank" rel="noopener noreferrer nofollow ugc">
             <strong>{{ comment.nick }}</strong>
           </a>
           <span class="tk-tag tk-tag-green" v-if="comment.master">{{ config.MASTER_TAG || t('COMMENT_MASTER_TAG') }}</span>


### PR DESCRIPTION
- `+ ugc` 符合最新语义（Google 自 2019） 

我调查了下其他的
- waline 是 nofollow noopener noreferrer
- artalk 是 noreferrer noopener nofollow
- valine 是 noopener

相关文档：
- nofollow 和 ugc 一起用以保证兼容性：https://developers.google.com/search/blog/2019/09/evolving-nofollow-new-ways-to-identify?hl=zh-cn#can-i-use-more-than-one-rel-value-on-a-link
- 几个用于出站链接的 rel 值（sponsored，ugc，nofollow）介绍：https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links?hl=zh-cn 