### PR TITLE
bugfix: 将a标签替换为button并移除href="#"和事件阻止

### DIFF
--- a/src/client/view/components/TkAction.vue
+++ b/src/client/view/components/TkAction.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="tk-action">
-    <a class="tk-action-link" :class="{ 'tk-liked': liked }" href="#" @click="onLike">
+    <button class="tk-action-link" :class="{ 'tk-liked': liked }" @click="onLike">
       <span class="tk-action-icon" v-html="iconLike"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconLikeSolid"></span>
       <span class="tk-action-count">{{ likeCountStr }}</span>
-    </a>
-    <a class="tk-action-link" :class="{ 'tk-disliked': disliked }" href="#" @click="onDislike" v-if="showDislike">
+    </button>
+    <button class="tk-action-link" :class="{ 'tk-disliked': disliked }" @click="onDislike" v-if="showDislike">
       <span class="tk-action-icon" v-html="iconDislike"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconDislikeSolid"></span>
       <span class="tk-action-count">{{ dislikeCountStr }}</span>
-    </a>
-    <a class="tk-action-link" href="#" @click="onReply">
+    </button>
+    <button class="tk-action-link" @click="onReply">
       <span class="tk-action-icon" v-html="iconComment"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconCommentSolid"></span>
       <span class="tk-action-count">{{ repliesCountStr }}</span>
-    </a>
+    </button>
   </div>
 </template>
 
@@ -57,16 +57,13 @@ export default {
     }
   },
   methods: {
-    onLike ($event) {
-      $event.preventDefault()
+    onLike () {
       this.$emit('like')
     },
-    onDislike ($event) {
-      $event.preventDefault()
+    onDislike () {
       this.$emit('dislike')
     },
-    onReply ($event) {
-      $event.preventDefault()
+    onReply () {
       this.$emit('reply')
     }
   }

--- a/src/client/view/components/TkAdmin.vue
+++ b/src/client/view/components/TkAdmin.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tk-admin-container">
     <div class="tk-admin" :class="{ '__show': show }" v-loading="loading">
-      <a class="tk-admin-close" href="#" @click="onClose" v-html="iconClose"></a>
+      <button class="tk-admin-close" @click="onClose" v-html="iconClose"></button>
       <div class="tk-login-title" v-if="needUpdate">
         <div>{{ t('ADMIN_NEED_UPDATE') }}</div>
         <a href="https://twikoo.js.org/update.html" target="_blank">https://twikoo.js.org/update.html</a>
@@ -212,8 +212,7 @@ export default {
         throw e
       }
     },
-    onClose ($event) {
-      $event.preventDefault()
+    onClose () {
       this.$emit('close')
     }
   },

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -19,10 +19,10 @@
             <time :datetime="jsonTimestamp" :title="localeTime">{{ displayCreated }}</time>
           </small>
           <small class="tk-actions" v-if="isLogin">
-            <a href="#" v-if="comment.isSpam" @click="handleSpam(false, $event)">{{ t('ADMIN_COMMENT_SHOW') }}</a>
-            <a href="#" v-if="!comment.isSpam" @click="handleSpam(true, $event)">{{ t('ADMIN_COMMENT_HIDE') }}</a>
-            <a href="#" v-if="!comment.rid && comment.top" @click="handleTop(false, $event)">{{ t('ADMIN_COMMENT_UNTOP') }}</a>
-            <a href="#" v-if="!comment.rid && !comment.top" @click="handleTop(true, $event)">{{ t('ADMIN_COMMENT_TOP') }}</a>
+            <button v-if="comment.isSpam" @click="handleSpam(false)">{{ t('ADMIN_COMMENT_SHOW') }}</button>
+            <button v-if="!comment.isSpam" @click="handleSpam(true)">{{ t('ADMIN_COMMENT_HIDE') }}</button>
+            <button v-if="!comment.rid && comment.top" @click="handleTop(false)">{{ t('ADMIN_COMMENT_UNTOP') }}</button>
+            <button v-if="!comment.rid && !comment.top" @click="handleTop(true)">{{ t('ADMIN_COMMENT_TOP') }}</button>
           </small>
         </div>
         <tk-action :liked="liked"
@@ -305,12 +305,10 @@ export default {
         this.isLogin = this.$twikoo.serverConfig && this.$twikoo.serverConfig.IS_ADMIN
       }
     },
-    handleSpam (isSpam, $event) {
-      $event.preventDefault()
+    handleSpam (isSpam) {
       this.setComment({ isSpam })
     },
-    handleTop (top, $event) {
-      $event.preventDefault()
+    handleTop (top) {
       this.setComment({ top })
     },
     popupLightbox (event) {


### PR DESCRIPTION
## 修改

- 将TkAdmin、TkComment和TkAction组件中的a标签替换为更语义化的button标签。

- 移除相关事件处理函数中不必要的preventDefault调用


## 解决了什么bug

- 已经在vitepress环境测试，点击行为正常符合预期，且无需再添加`class="vp-raw"`。

- 已修改范围内组件的样式不受影响。

- 理论上不会再在基于swup的主题中产生异常滚动。


## 相关Issue

见 #620 ，该issue中首次出现了`href="#"`代码及其相关的`preventDefault`用于解决vitepress中的问题。

见 #721 ，该issue提出了在基于swup的主题中异常滚动至顶部，且多人发现移除`href="#"`是有效的解决方案。顺带一提，这包括我自己。

[swup的跳转](https://github.com/swup/swup/blob/cf86cac54d4e90af9eed37e6f0432048a9a63e38/src/modules/scrollToContent.ts#L32)似乎是其模拟的结果，swup会提取链接的哈希并模拟原生行为进行跳转。当初通过`href="#"`解决vitepress的方案在这里产生了不可避免的副作用。

见 #832 ，[Ercilan](https://github.com/Ercilan)提出了使用button的方案，[vitepress的源代码](https://github.com/vuejs/vitepress/blob/b86ac8f3c5765c9a7537bfa7f02a40f5061b96ab/src/client/app/router.ts#L167)显示使用button可以完全规避跳转问题，且不会触发swup的哈希提取。

自行全局替换`href="#"`是一种难以持续的方案，很多基于swup的主题(尤其是自使用swup的[saicaca/fuwari](https://github.com/saicaca/fuwari)为主的分支)如[matsuzaka-yuki/Mizuki](https://github.com/matsuzaka-yuki/Mizuki)、[CuteLeaf/Firefly](https://github.com/CuteLeaf/Firefly)等等都在用不同方式为此付出额外的时间和代码，我希望能在这里彻底解决它。

