### PR TITLE
fix: 修复Vercel部署的云函数无法使用获取QQ昵称功能的问题

### DIFF
--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -30,6 +30,7 @@ const {
   isQQ,
   addQQMailSuffix,
   getQQAvatar,
+  getQQNick,
   getPasswordStatus,
   preCheckSpam,
   checkTurnstileCaptcha,
@@ -144,6 +145,9 @@ module.exports = async (request, response) => {
         break
       case 'UPLOAD_IMAGE': // >= 1.5.0
         res = await uploadImage(event, config)
+        break
+      case 'GET_QQ_NICK': // >= 1.7.0
+        res = await qqNickGet(event)
         break
       case 'COMMENT_EXPORT_FOR_ADMIN': // >= 1.6.13
         res = await commentExportForAdmin(event)
@@ -927,6 +931,21 @@ async function getRecentComments (event) {
   } catch (e) {
     res.message = e.message
     return res
+  }
+  return res
+}
+
+// 获取 QQ 昵称
+async function qqNickGet (event) {
+  const res = {}
+  try {
+    validate(event, ['qq'])
+    const nick = await getQQNick(event.qq, config.QQ_API_KEY)
+    res.code = RES_CODE.SUCCESS
+    res.nick = nick
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
   }
   return res
 }


### PR DESCRIPTION
当前的 twikoo-vercel 没有添加用于获取QQ昵称的路由，即使更新到最新版v1.7.7的 Vercel 云函数、配置了 QQ_API_KEY 也无法使用获取QQ昵称功能，提示“请更新 Twikoo 云函数至最新版本”，参考腾讯云函数添加获取QQ昵称的路由后恢复正常

### 修复前
<img width="1113" height="151" alt="01" src="https://github.com/user-attachments/assets/97de2eec-57eb-4964-8c70-156c4be1e273" />


### 修复后
<img width="1106" height="208" alt="02" src="https://github.com/user-attachments/assets/60b5423c-f3bd-4131-b479-1ad55c681f9a" />

## Summary by Sourcery

Bug Fixes:
- 通过将 `GET_QQ_NICK` 动作连接到 QQ 昵称获取逻辑，修复并恢复在 Vercel 部署中的 QQ 昵称查询功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore QQ nickname lookup in Vercel deployments by wiring the GET_QQ_NICK action to the QQ nickname retrieval logic.

</details>