### PR TITLE
feat: allow users to delete their own comments

### DIFF
--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1544,6 +1544,15 @@ export default {
     '返信',
     '답글'
   ],
+  COMMENT_DELETE_CONFIRM: [
+    '确认删除你的评论？',
+    '確認刪除你的評論？',
+    '確認刪除你的評論？',
+    'Delete your comment?',
+    'Izohingizni o\'chirasizmi?',
+    'あなたのコメントを削除しますか？',
+    '댓글을 삭제하시겠습니까?'
+  ],
   COMMENT_REVIEWING_TAG: [
     '审核中',
     '審核中',

--- a/src/client/view/components/TkAction.vue
+++ b/src/client/view/components/TkAction.vue
@@ -3,6 +3,7 @@
     <button class="tk-action-link" @click="onDelete" v-if="showDelete">
       <span class="tk-action-icon" v-html="iconDelete"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconDeleteSolid"></span>
+      <span class="tk-action-count"></span>
     </button>
     <button class="tk-action-link" :class="{ 'tk-liked': liked }" @click="onLike">
       <span class="tk-action-icon" v-html="iconLike"></span>

--- a/src/client/view/components/TkAction.vue
+++ b/src/client/view/components/TkAction.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="tk-action">
+    <button class="tk-action-link" @click="onDelete" v-if="showDelete">
+      <span class="tk-action-icon" v-html="iconDelete"></span>
+      <span class="tk-action-icon tk-action-icon-solid" v-html="iconDeleteSolid"></span>
+    </button>
     <button class="tk-action-link" :class="{ 'tk-liked': liked }" @click="onLike">
       <span class="tk-action-icon" v-html="iconLike"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconLikeSolid"></span>
@@ -14,10 +18,6 @@
       <span class="tk-action-icon" v-html="iconComment"></span>
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconCommentSolid"></span>
       <span class="tk-action-count">{{ repliesCountStr }}</span>
-    </button>
-    <button class="tk-action-link" @click="onDelete" v-if="showDelete">
-      <span class="tk-action-icon" v-html="iconDelete"></span>
-      <span class="tk-action-icon tk-action-icon-solid" v-html="iconDeleteSolid"></span>
     </button>
   </div>
 </template>

--- a/src/client/view/components/TkAction.vue
+++ b/src/client/view/components/TkAction.vue
@@ -15,6 +15,10 @@
       <span class="tk-action-icon tk-action-icon-solid" v-html="iconCommentSolid"></span>
       <span class="tk-action-count">{{ repliesCountStr }}</span>
     </button>
+    <button class="tk-action-link" @click="onDelete" v-if="showDelete">
+      <span class="tk-action-icon" v-html="iconDelete"></span>
+      <span class="tk-action-icon tk-action-icon-solid" v-html="iconDeleteSolid"></span>
+    </button>
   </div>
 </template>
 
@@ -25,6 +29,8 @@ import iconLike from '@fortawesome/fontawesome-free/svgs/regular/thumbs-up.svg'
 import iconLikeSolid from '@fortawesome/fontawesome-free/svgs/solid/thumbs-up.svg'
 import iconDislike from '@fortawesome/fontawesome-free/svgs/regular/thumbs-down.svg'
 import iconDislikeSolid from '@fortawesome/fontawesome-free/svgs/solid/thumbs-down.svg'
+import iconDelete from '@fortawesome/fontawesome-free/svgs/regular/trash-alt.svg'
+import iconDeleteSolid from '@fortawesome/fontawesome-free/svgs/solid/trash-alt.svg'
 
 export default {
   data () {
@@ -34,7 +40,9 @@ export default {
       iconLike,
       iconLikeSolid,
       iconDislike,
-      iconDislikeSolid
+      iconDislikeSolid,
+      iconDelete,
+      iconDeleteSolid
     }
   },
   props: {
@@ -43,7 +51,8 @@ export default {
     likeCount: Number,
     dislikeCount: Number,
     repliesCount: Number,
-    showDislike: Boolean
+    showDislike: Boolean,
+    showDelete: Boolean
   },
   computed: {
     likeCountStr () {
@@ -65,6 +74,9 @@ export default {
     },
     onReply () {
       this.$emit('reply')
+    },
+    onDelete () {
+      this.$emit('delete')
     }
   }
 }

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -261,7 +261,7 @@ export default {
     },
     async onDelete () {
       if (!confirm(t('COMMENT_DELETE_CONFIRM'))) return
-      const result = await call(this.$tcb, 'COMMENT_DELETE_FOR_USER', {
+      const { result } = await call(this.$tcb, 'COMMENT_DELETE_FOR_USER', {
         id: this.comment.id
       })
       if (result.code) {

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -260,11 +260,13 @@ export default {
       this.$emit('reply', this.comment.id)
     },
     async onDelete () {
-      if (!confirm(t('ADMIN_COMMENT_DELETE_CONFIRM'))) return
+      if (!confirm(t('COMMENT_DELETE_CONFIRM'))) return
       const result = await call(this.$tcb, 'COMMENT_DELETE_FOR_USER', {
         id: this.comment.id
       })
-      if (!result.code) {
+      if (result.code) {
+        alert(result.message)
+      } else {
         this.$emit('load')
       }
     },

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -31,9 +31,11 @@
             :dislike-count="downs"
             :replies-count="comment.replies.length"
             :show-dislike="config.SHOW_DISLIKE !== 'false'"
+            :show-delete="comment.isOwner"
             @like="onLike"
             @dislike="onDislike"
-            @reply="onReply" />
+            @reply="onReply"
+            @delete="onDelete" />
       </div>
       <div class="tk-content" :class="{ 'tk-content-expand': isContentExpanded || !showContentExpand }" ref="tk-content">
         <span v-if="comment.pid">{{ t('COMMENT_REPLIED') }} <a class="tk-ruser" :href="`#${comment.pid}`">@{{ comment.ruser }}</a> :</span>
@@ -256,6 +258,15 @@ export default {
     onReply (id) {
       this.pid = id
       this.$emit('reply', this.comment.id)
+    },
+    async onDelete () {
+      if (!confirm(t('ADMIN_COMMENT_DELETE_CONFIRM'))) return
+      const result = await call(this.$tcb, 'COMMENT_DELETE_FOR_USER', {
+        id: this.comment.id
+      })
+      if (!result.code) {
+        this.$emit('load')
+      }
     },
     onReplyReply (id) {
       // 楼中楼回复

--- a/src/server/eo-pages/node-functions/index.js
+++ b/src/server/eo-pages/node-functions/index.js
@@ -35,7 +35,8 @@ import {
   checkCapCaptcha,
   getConfig,
   getConfigForAdmin,
-  validate
+  validate,
+  checkCommentOwnership
 } from 'twikoo-func/utils'
 import {
   jsonParse,
@@ -566,19 +567,10 @@ async function commentDeleteForAdmin (event, db, accessToken) {
 async function commentDeleteForUser (event, db, accessToken) {
   const res = {}
   try {
-    validate(event, ['id'])
     const uid = accessToken
-    const comment = await db.getComment(event.id)
-    if (!comment) {
-      res.code = RES_CODE.FAIL
-      res.message = '评论不存在'
-      return res
-    }
-    if (comment.uid !== uid) {
-      res.code = RES_CODE.FAIL
-      res.message = '只能删除自己的评论'
-      return res
-    }
+    await checkCommentOwnership(event.id, uid, async (id) => {
+      return db.getComment(id)
+    })
     await db.deleteComment(event.id)
     res.code = RES_CODE.SUCCESS
     res.deleted = 1

--- a/src/server/eo-pages/node-functions/index.js
+++ b/src/server/eo-pages/node-functions/index.js
@@ -562,6 +562,33 @@ async function commentDeleteForAdmin (event, db, accessToken) {
   return res
 }
 
+// 用户删除自己的评论
+async function commentDeleteForUser (event, db, accessToken) {
+  const res = {}
+  try {
+    validate(event, ['id'])
+    const uid = accessToken
+    const comment = await db.getComment(event.id)
+    if (!comment) {
+      res.code = RES_CODE.FAIL
+      res.message = '评论不存在'
+      return res
+    }
+    if (comment.uid !== uid) {
+      res.code = RES_CODE.FAIL
+      res.message = '只能删除自己的评论'
+      return res
+    }
+    await db.deleteComment(event.id)
+    res.code = RES_CODE.SUCCESS
+    res.deleted = 1
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
+  }
+  return res
+}
+
 async function commentImportForAdmin (event, db, accessToken) {
   const res = {}
   let logText = ''
@@ -1105,6 +1132,9 @@ async function handlePost (req, res) {
         break
       case 'COMMENT_DELETE_FOR_ADMIN':
         result = await commentDeleteForAdmin(event, db, accessToken)
+        break
+      case 'COMMENT_DELETE_FOR_USER':
+        result = await commentDeleteForUser(event, db, accessToken)
         break
       case 'COMMENT_IMPORT_FOR_ADMIN':
         result = await commentImportForAdmin(event, db, accessToken)

--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -34,7 +34,8 @@ const {
   checkCapCaptcha,
   getConfig,
   getConfigForAdmin,
-  validate
+  validate,
+  checkCommentOwnership
 } = require('./utils')
 const {
   jsonParse,
@@ -435,20 +436,11 @@ async function commentDeleteForAdmin (event) {
 async function commentDeleteForUser (event) {
   const res = {}
   try {
-    validate(event, ['id'])
     const uid = await getUid()
-    const doc = await db.collection('comment').doc(event.id).get()
-    if (!doc.data || doc.data.length === 0) {
-      res.code = RES_CODE.FAIL
-      res.message = '评论不存在'
-      return res
-    }
-    const comment = doc.data[0]
-    if (comment.uid !== uid) {
-      res.code = RES_CODE.FAIL
-      res.message = '只能删除自己的评论'
-      return res
-    }
+    await checkCommentOwnership(event.id, uid, async (id) => {
+      const doc = await db.collection('comment').doc(id).get()
+      return doc.data && doc.data.length > 0 ? doc.data[0] : null
+    })
     const data = await db.collection('comment').doc(event.id).delete()
     res.code = RES_CODE.SUCCESS
     res.deleted = data.deleted

--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -146,6 +146,9 @@ exports.main = async (event, context) => {
       case 'COMMENT_EXPORT_FOR_ADMIN': // >= 1.6.13
         res = await commentExportForAdmin(event)
         break
+      case 'COMMENT_DELETE_FOR_USER':
+        res = await commentDeleteForUser(event)
+        break
       default:
         if (event.event) {
           res.code = RES_CODE.EVENT_NOT_EXIST
@@ -424,6 +427,34 @@ async function commentDeleteForAdmin (event) {
   } else {
     res.code = RES_CODE.NEED_LOGIN
     res.message = '请先登录'
+  }
+  return res
+}
+
+// 用户删除自己的评论
+async function commentDeleteForUser (event) {
+  const res = {}
+  try {
+    validate(event, ['id'])
+    const uid = await getUid()
+    const doc = await db.collection('comment').doc(event.id).get()
+    if (!doc.data || doc.data.length === 0) {
+      res.code = RES_CODE.FAIL
+      res.message = '评论不存在'
+      return res
+    }
+    const comment = doc.data[0]
+    if (comment.uid !== uid) {
+      res.code = RES_CODE.FAIL
+      res.message = '只能删除自己的评论'
+      return res
+    }
+    const data = await db.collection('comment').doc(event.id).delete()
+    res.code = RES_CODE.SUCCESS
+    res.deleted = data.deleted
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
   }
   return res
 }

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -446,6 +446,18 @@ const fn = {
         throw new Error(`参数"${requiredParam}"不合法`)
       }
     }
+  },
+  // 校验评论归属：确认评论存在且属于当前用户
+  async checkCommentOwnership (id, uid, getComment) {
+    fn.validate({ id }, ['id'])
+    const comment = await getComment(id)
+    if (!comment) {
+      throw new Error('评论不存在')
+    }
+    if (comment.uid !== uid) {
+      throw new Error('只能删除自己的评论')
+    }
+    return comment
   }
 }
 

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -99,6 +99,7 @@ const fn = {
       ruser: fn.ruser(comment.pid, comments),
       top: comment.top,
       isSpam: comment.isSpam,
+      isOwner: comment.uid === uid,
       created: comment.created,
       updated: comment.updated
     }

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -39,7 +39,8 @@ const {
   checkCapCaptcha,
   getConfig,
   getConfigForAdmin,
-  validate
+  validate,
+  checkCommentOwnership
 } = require('twikoo-func/utils')
 const {
   jsonParse,
@@ -481,24 +482,11 @@ async function commentDeleteForAdmin (event) {
 async function commentDeleteForUser (event) {
   const res = {}
   try {
-    validate(event, ['id'])
     const uid = event.accessToken
-    const comment = db
-      .getCollection('comment')
-      .findOne({ _id: event.id })
-    if (!comment) {
-      res.code = RES_CODE.FAIL
-      res.message = '评论不存在'
-      return res
-    }
-    if (comment.uid !== uid) {
-      res.code = RES_CODE.FAIL
-      res.message = '只能删除自己的评论'
-      return res
-    }
-    db
-      .getCollection('comment')
-      .findAndRemove({ _id: event.id })
+    await checkCommentOwnership(event.id, uid, (id) => {
+      return db.getCollection('comment').findOne({ _id: id })
+    })
+    db.getCollection('comment').findAndRemove({ _id: event.id })
     res.code = RES_CODE.SUCCESS
     res.deleted = 1
   } catch (e) {

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -103,6 +103,9 @@ module.exports = async (request, response) => {
       case 'COMMENT_DELETE_FOR_ADMIN':
         res = await commentDeleteForAdmin(event)
         break
+      case 'COMMENT_DELETE_FOR_USER':
+        res = await commentDeleteForUser(event)
+        break
       case 'COMMENT_IMPORT_FOR_ADMIN':
         res = await commentImportForAdmin(event)
         break
@@ -470,6 +473,37 @@ async function commentDeleteForAdmin (event) {
   } else {
     res.code = RES_CODE.NEED_LOGIN
     res.message = '请先登录'
+  }
+  return res
+}
+
+// 用户删除自己的评论
+async function commentDeleteForUser (event) {
+  const res = {}
+  try {
+    validate(event, ['id'])
+    const uid = event.accessToken
+    const comment = db
+      .getCollection('comment')
+      .findOne({ _id: event.id })
+    if (!comment) {
+      res.code = RES_CODE.FAIL
+      res.message = '评论不存在'
+      return res
+    }
+    if (comment.uid !== uid) {
+      res.code = RES_CODE.FAIL
+      res.message = '只能删除自己的评论'
+      return res
+    }
+    db
+      .getCollection('comment')
+      .findAndRemove({ _id: event.id })
+    res.code = RES_CODE.SUCCESS
+    res.deleted = 1
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
   }
   return res
 }

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -36,7 +36,8 @@ const {
   checkCapCaptcha,
   getConfig,
   getConfigForAdmin,
-  validate
+  validate,
+  checkCommentOwnership
 } = require('twikoo-func/utils')
 const {
   jsonParse,
@@ -467,24 +468,11 @@ async function commentDeleteForAdmin (event) {
 async function commentDeleteForUser (event) {
   const res = {}
   try {
-    validate(event, ['id'])
     const uid = event.accessToken
-    const comment = await db
-      .collection('comment')
-      .findOne({ _id: event.id })
-    if (!comment) {
-      res.code = RES_CODE.FAIL
-      res.message = '评论不存在'
-      return res
-    }
-    if (comment.uid !== uid) {
-      res.code = RES_CODE.FAIL
-      res.message = '只能删除自己的评论'
-      return res
-    }
-    const data = await db
-      .collection('comment')
-      .deleteOne({ _id: event.id })
+    await checkCommentOwnership(event.id, uid, async (id) => {
+      return db.collection('comment').findOne({ _id: id })
+    })
+    const data = await db.collection('comment').deleteOne({ _id: event.id })
     res.code = RES_CODE.SUCCESS
     res.deleted = data.deletedCount
   } catch (e) {

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -99,6 +99,9 @@ module.exports = async (request, response) => {
       case 'COMMENT_DELETE_FOR_ADMIN':
         res = await commentDeleteForAdmin(event)
         break
+      case 'COMMENT_DELETE_FOR_USER':
+        res = await commentDeleteForUser(event)
+        break
       case 'COMMENT_IMPORT_FOR_ADMIN':
         res = await commentImportForAdmin(event)
         break
@@ -456,6 +459,37 @@ async function commentDeleteForAdmin (event) {
   } else {
     res.code = RES_CODE.NEED_LOGIN
     res.message = '请先登录'
+  }
+  return res
+}
+
+// 用户删除自己的评论
+async function commentDeleteForUser (event) {
+  const res = {}
+  try {
+    validate(event, ['id'])
+    const uid = event.accessToken
+    const comment = await db
+      .collection('comment')
+      .findOne({ _id: event.id })
+    if (!comment) {
+      res.code = RES_CODE.FAIL
+      res.message = '评论不存在'
+      return res
+    }
+    if (comment.uid !== uid) {
+      res.code = RES_CODE.FAIL
+      res.message = '只能删除自己的评论'
+      return res
+    }
+    const data = await db
+      .collection('comment')
+      .deleteOne({ _id: event.id })
+    res.code = RES_CODE.SUCCESS
+    res.deleted = data.deletedCount
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
   }
   return res
 }

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -38,7 +38,8 @@ const {
   checkCapCaptcha,
   getConfig,
   getConfigForAdmin,
-  validate
+  validate,
+  checkCommentOwnership
 } = require('twikoo-func/utils')
 const {
   jsonParse,
@@ -477,24 +478,11 @@ async function commentDeleteForAdmin (event) {
 async function commentDeleteForUser (event) {
   const res = {}
   try {
-    validate(event, ['id'])
     const uid = getUid()
-    const comment = await db
-      .collection('comment')
-      .findOne({ _id: event.id })
-    if (!comment) {
-      res.code = RES_CODE.FAIL
-      res.message = '评论不存在'
-      return res
-    }
-    if (comment.uid !== uid) {
-      res.code = RES_CODE.FAIL
-      res.message = '只能删除自己的评论'
-      return res
-    }
-    const data = await db
-      .collection('comment')
-      .deleteOne({ _id: event.id })
+    await checkCommentOwnership(event.id, uid, async (id) => {
+      return db.collection('comment').findOne({ _id: id })
+    })
+    const data = await db.collection('comment').deleteOne({ _id: event.id })
     res.code = RES_CODE.SUCCESS
     res.deleted = data.deletedCount
   } catch (e) {

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -101,6 +101,9 @@ module.exports = async (request, response) => {
       case 'COMMENT_DELETE_FOR_ADMIN':
         res = await commentDeleteForAdmin(event)
         break
+      case 'COMMENT_DELETE_FOR_USER':
+        res = await commentDeleteForUser(event)
+        break
       case 'COMMENT_IMPORT_FOR_ADMIN':
         res = await commentImportForAdmin(event)
         break
@@ -466,6 +469,37 @@ async function commentDeleteForAdmin (event) {
   } else {
     res.code = RES_CODE.NEED_LOGIN
     res.message = '请先登录'
+  }
+  return res
+}
+
+// 用户删除自己的评论
+async function commentDeleteForUser (event) {
+  const res = {}
+  try {
+    validate(event, ['id'])
+    const uid = getUid()
+    const comment = await db
+      .collection('comment')
+      .findOne({ _id: event.id })
+    if (!comment) {
+      res.code = RES_CODE.FAIL
+      res.message = '评论不存在'
+      return res
+    }
+    if (comment.uid !== uid) {
+      res.code = RES_CODE.FAIL
+      res.message = '只能删除自己的评论'
+      return res
+    }
+    const data = await db
+      .collection('comment')
+      .deleteOne({ _id: event.id })
+    res.code = RES_CODE.SUCCESS
+    res.deleted = data.deletedCount
+  } catch (e) {
+    res.code = RES_CODE.FAIL
+    res.message = e.message
   }
   return res
 }


### PR DESCRIPTION
Add a delete button to TkAction that is only visible when the current user owns the comment (determined by the server-side `isOwner` field in toCommentDto). The server validates ownership via uid comparison before allowing deletion. All 5 server backends (CloudBase, self-hosted LokiJS, self-hosted MongoDB, Vercel, EdgeOne Pages) are supported.

## 由 Sourcery 提供的摘要

允许终端用户删除自己的评论，在所有后端通过服务器端的所有权验证，并提供相应的 UI 控件。

新功能：
- 在评论 UI 中添加用户主动发起的评论删除操作，仅对评论所有者可见。
- 在所有受支持的服务器后端中暴露新的 `COMMENT_DELETE_FOR_USER` API/事件，用于处理自助评论删除。

增强：
- 在评论 DTO 中包含 `isOwner` 标志，以指示当前用户是否拥有各条评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow end users to delete their own comments with server-side ownership validation across all backends and corresponding UI controls.

New Features:
- Add a user-initiated comment deletion action to the comment UI, visible only to the comment owner.
- Expose a new COMMENT_DELETE_FOR_USER API/event on all supported server backends to handle self-service comment deletion.

Enhancements:
- Include an isOwner flag in comment DTOs to indicate whether the current user owns each comment.

</details>