### PR TITLE
fix(import): normalize JSON-stringified like/ups/downs arrays on Twikoo import

### DIFF
--- a/src/server/function/twikoo/utils/import.js
+++ b/src/server/function/twikoo/utils/import.js
@@ -3,6 +3,41 @@ const { getMarked, getDomPurify, getMd5 } = require('./lib')
 const marked = getMarked()
 const md5 = getMd5()
 
+const ARRAY_FIELDS = ['like', 'ups', 'downs']
+
+const parseJsonArrayField = (value) => {
+  if (Array.isArray(value)) return value
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('[')) return value
+  try {
+    const parsed = JSON.parse(trimmed)
+    return Array.isArray(parsed) ? parsed : value
+  } catch (e) {
+    return value
+  }
+}
+
+const normalizeTwikooComment = (comment) => {
+  const parsed = { ...comment }
+  if (comment._id && comment._id.$oid) {
+    // 解决 id 历史数据问题
+    parsed._id = comment._id.$oid
+  }
+  if (comment.pid === null) {
+    delete parsed.pid
+  }
+  if (comment.rid === null) {
+    delete parsed.rid
+  }
+  for (const field of ARRAY_FIELDS) {
+    if (field in parsed) {
+      parsed[field] = parseJsonArrayField(parsed[field])
+    }
+  }
+  return parsed
+}
+
 const fn = {
   // 兼容 Leancloud 两种 JSON 导出格式
   jsonParse (content) {
@@ -240,17 +275,7 @@ const fn = {
     log(`共 ${arr.length} 条评论`)
     for (const comment of arr) {
       try {
-        const parsed = comment
-        if (comment._id.$oid) {
-          // 解决 id 历史数据问题
-          parsed._id = comment._id.$oid
-        }
-        if (comment.pid === null) {
-          delete comment.pid
-        }
-        if (comment.rid === null) {
-          delete comment.rid
-        }
+        const parsed = normalizeTwikooComment(comment)
         comments.push(parsed)
         log(`${comment._id} 解析成功`)
       } catch (e) {


### PR DESCRIPTION
## Summary
- Normalize `like`, `ups`, and `downs` during Twikoo JSON import when those fields were exported as JSON-stringified strings (e.g. `"[]"`) instead of real arrays
- Avoid mutating the source comment object while normalizing `_id`, `pid`, and `rid`

## Problem
Fixes #845. Importing Twikoo JSON with `like: "[]"` stored the value as a string, and subsequent export/import cycles double-escaped it to `"\"[]\""`.

## Test plan
- [x] Manual logic review for `like: "[]"`, `ups: "[]"`, and already-array values
- [ ] Import a Twikoo JSON file containing `like: "[]"` and verify DB stores `[]`
- [ ] Export and re-import to confirm no double-escaping

## Summary by Sourcery

在进行 JSON 导入时对 Twikoo 评论数据进行规范化处理，以支持旧版 ID 格式和类数组字段，同时不修改原始记录。

Bug Fixes:
- 确保从 Twikoo JSON 导入的 `like`、`ups` 和 `downs` 字段在被以 JSON 字符串形式导出时，依然会被存储为数组。

Enhancements:
- 抽取可复用的 Twikoo 评论规范化助手，用于清理旧格式的 `_id`、`pid` 和 `rid` 值，同时不对源对象进行修改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Twikoo comment data during JSON import to handle legacy ID formats and array-like fields without mutating the original records.

Bug Fixes:
- Ensure `like`, `ups`, and `downs` fields imported from Twikoo JSON are stored as arrays even when exported as JSON-stringified strings.

Enhancements:
- Extract a reusable Twikoo comment normalization helper to clean up legacy `_id`, `pid`, and `rid` values without mutating the source objects.

</details>