### PR TITLE
fix(ui): allow horizontal scroll for long code block lines

### DIFF
--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -234,6 +234,16 @@ export default {
   position: relative;
   border-radius: .3em
 }
+.twikoo .tk-content pre,
+.twikoo .tk-preview-container pre {
+  overflow-x: auto;
+  max-width: 100%;
+}
+.twikoo .tk-content pre code,
+.twikoo .tk-preview-container pre code {
+  white-space: pre;
+  word-break: normal;
+}
 .twikoo div.code-toolbar>.toolbar {
   position: absolute;
   right: 4px;


### PR DESCRIPTION
## Summary
- Add horizontal scrolling for `<pre>` blocks inside comment content and preview
- Preserve `white-space: pre` on code lines so long lines scroll instead of being clipped

## Problem
Fixes #839. Long single-line code blocks were clipped by `.tk-content { overflow: hidden }` with no way to view the hidden portion.

## Test plan
- [ ] Post a comment containing a code block with a very long single line
- [ ] Confirm a horizontal scrollbar appears and the full line is reachable
- [ ] Verify preview mode shows the same scroll behavior

## Summary by Sourcery

为评论内容和预览中的长代码块启用横向滚动，以确保在现有布局中完整代码行仍然可访问。

Bug Fixes:
- 防止评论和预览中的长单行代码块由于容器溢出设置而在视觉上被裁剪。

Enhancements:
- 统一评论和预览中的代码块样式，使长行在保持预格式化空白的同时，仍可在视口内滚动查看。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable horizontal scrolling for long code blocks in comment content and preview to ensure full lines remain accessible within the existing layout.

Bug Fixes:
- Prevent long single-line code blocks in comments and preview from being visually clipped by container overflow settings.

Enhancements:
- Standardize code block styling in comments and preview so long lines maintain preformatted spacing while remaining scrollable within the viewport.

</details>