### PR TITLE
fix(markdown): disable indented code blocks in comment rendering

### DIFF
--- a/src/client/utils/marked.js
+++ b/src/client/utils/marked.js
@@ -13,4 +13,15 @@ marked.setOptions({
   smartypants: true
 })
 
+// Comment UIs rarely use indented (4-space) code blocks, but users often
+// prefix lines with spaces for visual indentation — which Markdown would
+// otherwise render as a code block (#855).
+marked.use({
+  tokenizer: {
+    code () {
+      return undefined
+    }
+  }
+})
+
 export default marked


### PR DESCRIPTION
## Summary
Disable Markdown's legacy 4-space indented code blocks in Twikoo comment rendering. Fenced ``` code blocks remain supported.

## Problem
Fixes #855. Users who prefix lines with four spaces for visual indentation were getting code-block layout instead of normal paragraph text.

## Test plan
- [ ] Comment with lines starting with four spaces renders as paragraph text
- [ ] Fenced ``` code blocks still render correctly
- [ ] Preview mode behaves the same as submitted comments

## Summary by Sourcery

Bug Fixes:
- 防止注释中以四个空格开头的行被错误渲染为缩进代码块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent lines starting with four spaces in comments from being rendered as unintended indented code blocks.

</details>