### PR TITLE
fix(admin): wrap config panel secret fields in a form

### DIFF
--- a/src/client/view/components/TkAdminConfig.vue
+++ b/src/client/view/components/TkAdminConfig.vue
@@ -5,6 +5,7 @@
       <span>{{ t('ADMIN_SERVER_VERSION') }}{{ serverVersion }}，</span>
       <span>请参考&nbsp;<a href="https://twikoo.js.org/update.html" target="_blank">版本更新</a>&nbsp;进行升级</span>
     </div>
+    <form @submit.prevent="saveConfig">
     <div class="tk-admin-config-groups">
       <details class="tk-admin-config-group" v-for="settingGroup in settings" :key="settingGroup.name">
         <summary class="tk-admin-config-group-title">{{ settingGroup.name }}</summary>
@@ -34,9 +35,10 @@
       </details>
     </div>
     <div class="tk-admin-config-actions">
-      <el-button size="small" type="primary" @click="saveConfig">{{ t('ADMIN_CONFIG_SAVE') }}</el-button>
+      <el-button size="small" type="primary" native-type="submit">{{ t('ADMIN_CONFIG_SAVE') }}</el-button>
       <el-button size="small" type="info" @click="resetConfig">{{ t('ADMIN_CONFIG_RESET') }}</el-button>
     </div>
+    </form>
     <div class="tk-admin-config-message">{{ message }}</div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
Wrap the admin config editor in a `<form>` so secret settings that use password inputs are associated with a form element.

## Problem
Fixes #680. Chrome warns when password fields are rendered outside a form; Twikoo's admin config panel had secret keys using `show-password` without a surrounding form.

## Test plan
- [ ] Open admin config tab and verify no console warning about password fields
- [ ] Save and reset config still work as before

## Summary by Sourcery

Bug Fixes:
- 将管理员配置中的密码输入字段与表单关联起来，以消除 Chrome 关于“表单外的密码字段”的警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Associate admin config password inputs with a form to eliminate Chrome warnings about password fields outside a form.

</details>