### PR TITLE
fix(comments): keep expanded list after show/hide moderation

### DIFF
--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -347,7 +347,7 @@ export default {
         set
       })
       this.loading = false
-      this.$emit('load')
+      Object.assign(this.comment, set)
     }
   },
   mounted () {


### PR DESCRIPTION
## Summary
When an admin shows/hides or tops/untops a comment from the public comment list, update that comment in place instead of reloading the entire comment list.

## Problem
Fixes #527. Moderation actions emitted `load`, which triggered `initComments` and reset the list to the first page, collapsing comments the user had already expanded.

## Test plan
- [ ] Expand more comments on a page with many comments
- [ ] Show or hide a pending comment from the inline admin controls
- [ ] Confirm previously expanded comments stay loaded

## Summary by Sourcery

Bug Fixes:
- 在执行显示/隐藏或置顶/取消置顶等审核操作时，保留当前评论列表的状态，包括已展开的评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Preserve the current comment list state, including expanded comments, when performing moderation actions such as show/hide or top/untop.

</details>