### PR TITLE
fix(admin): correct close button layout and mobile backdrop

### DIFF
--- a/src/client/view/components/TkAdmin.vue
+++ b/src/client/view/components/TkAdmin.vue
@@ -244,7 +244,8 @@ export default {
   overflow-y: auto;
   pointer-events: all;
   color: #ffffff;
-  background-color: rgba(0,0,0,0.60);
+  background-color: rgba(0, 0, 0, 0.85);
+  -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   transition: all 0.5s ease;
   visibility: hidden;
@@ -271,10 +272,9 @@ export default {
   text-decoration: none;
   cursor: pointer;
   position: sticky;
-  float: right;
   display: block;
-  top: 0;
-  right: 0;
+  top: 1rem;
+  left: calc(100% - 3rem);
   width: 1rem;
   height: 1rem;
   padding: 1rem;


### PR DESCRIPTION
## Summary

Fixes #161

- Remove `float: right` from the sticky close button and position it with `left: calc(100% - 3rem)` so the login panel remains centered
- Add `-webkit-backdrop-filter` and a darker fallback `background-color` for browsers that do not render `backdrop-filter` (reported on mobile QQ)

## Test plan

- [ ] Open admin panel login view — content should be centered, close button in top-right
- [ ] Scroll admin panel with long content — close button stays sticky at top
- [ ] Verify backdrop on mobile WebView / browsers without backdrop-filter support

## Summary by Sourcery

修复管理员登录覆盖层样式，在保持内容居中显示的同时，确保关闭按钮位置正确，并改善在移动端浏览器上的背景遮罩效果。

Bug 修复：
- 修正管理员登录视图中固定关闭按钮的位置，使其始终位于右上角，同时不影响面板的居中显示。
- 调整管理员登录背景遮罩样式，使其在不完全支持 `backdrop-filter` 的移动端和 WebView 浏览器中也能正常渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix admin login overlay styling to keep the close button correctly positioned while preserving centered content and improving backdrop appearance on mobile browsers.

Bug Fixes:
- Correct the sticky close button positioning in the admin login view so it stays in the top-right without breaking panel centering.
- Adjust the admin login backdrop styling to render appropriately on mobile and WebView browsers that lack full backdrop-filter support.

</details>