### PR TITLE
fix(ui): prevent hash links from jumping to page top

### DIFF
--- a/src/client/view/components/TkAdmin.vue
+++ b/src/client/view/components/TkAdmin.vue
@@ -43,7 +43,7 @@
         <div class="tk-panel" v-if="isLogin">
           <div class="tk-panel-title">
             <div>{{ t('ADMIN_TITLE') }}</div>
-            <a class="tk-panel-logout" href="#" @click="onLogout">{{ t('ADMIN_LOGOUT') }}</a>
+            <a class="tk-panel-logout" href="#" @click.prevent="onLogout">{{ t('ADMIN_LOGOUT') }}</a>
           </div>
           <div class="tk-tabs">
             <div class="tk-tab" :class="{ __active: activeTabName === 'comment' }" @click="activeTabName = 'comment'">{{ t('ADMIN_COMMENT') }}</div>

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -38,7 +38,7 @@
             @delete="onDelete" />
       </div>
       <div class="tk-content" :class="{ 'tk-content-expand': isContentExpanded || !showContentExpand }" ref="tk-content">
-        <span v-if="comment.pid">{{ t('COMMENT_REPLIED') }} <a class="tk-ruser" :href="`#${comment.pid}`">@{{ comment.ruser }}</a> :</span>
+        <span v-if="comment.pid">{{ t('COMMENT_REPLIED') }} <a class="tk-ruser" href="#" @click.prevent="scrollToPid(comment.pid)">@{{ comment.ruser }}</a> :</span>
         <span v-html="comment.comment" ref="comment" @click="popupLightbox"></span>
       </div>
       <div class="tk-expand-wrap" v-if="showContentExpand">
@@ -221,6 +221,15 @@ export default {
           behavior: 'smooth'
         })
         this.$emit('expand')
+      }
+    },
+    scrollToPid (pid) {
+      const el = document.getElementById(pid)
+      if (el) {
+        el.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        })
       }
     },
     async onLike () {


### PR DESCRIPTION
## Summary

Fixes #832

- Admin logout link now uses `@click.prevent` to avoid `href="#"` navigation
- @user reply links scroll to the target comment in-page instead of using hash URLs that reset scroll position in swup/SPA themes

## Test plan

- [ ] Like/reply/expand comments on a swup-powered site — page should stay at current scroll position
- [ ] Open admin panel, click logout — should not jump to page top
- [ ] Click @user in a reply — should scroll to referenced comment

## Summary by Sourcery

通过在应用内部对哈希链接（hash links）进行处理，使用页面内滚动行为和安全的点击事件处理程序，避免因点击应用内哈希链接导致整页跳转。

Bug 修复：
- 确保管理员登出链接在点击时不再触发页面跳转到顶部。
- 使 @user 回复链接平滑滚动到被引用的评论位置，而不是通过会重置滚动位置的哈希 URL 进行导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent in-app hash links from causing full-page jumps by handling them with in-page scroll behavior and safe click handlers.

Bug Fixes:
- Ensure admin logout link no longer triggers navigation to page top when clicked.
- Make @user reply links scroll smoothly to the referenced comment instead of navigating via hash URLs that reset scroll position.

</details>