### PR TITLE
fix(meta): clear nick when QQ nickname fetch fails

### DIFF
--- a/src/client/view/components/TkMetaInput.vue
+++ b/src/client/view/components/TkMetaInput.vue
@@ -102,15 +102,24 @@ export default {
         this.getQQNick(qqNum)
       }
     },
+    clearNickIfFromQQInput () {
+      if (isQQ(this.metaData.nick)) {
+        this.metaData.nick = ''
+        this.updateMeta()
+      }
+    },
     async getQQNick (qqNum) {
       try {
         const { result } = await call(null, 'GET_QQ_NICK', { qq: qqNum })
         if (result && result.nick) {
           this.metaData.nick = result.nick
           this.updateMeta()
+        } else {
+          this.clearNickIfFromQQInput()
         }
       } catch (e) {
         console.warn('获取 QQ 昵称失败：', e)
+        this.clearNickIfFromQQInput()
       }
     },
     checkAdminCrypt () {


### PR DESCRIPTION
## Summary

Fixes #816

When a visitor enters a QQ number in the nickname field and the QQ nickname API fails or returns empty, clear the nickname field instead of leaving the raw QQ number visible in comments.

## Test plan

- [ ] Enter a QQ number in the nickname field with QQ API unavailable — nick field should become empty
- [ ] Enter a QQ number with working API — nick should still auto-fill correctly

## Summary by Sourcery

错误修复：
- 当获取 QQ 昵称失败或返回为空时，清空昵称字段，以避免将 QQ 号码显示为昵称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clear the nickname field when QQ nickname fetching fails or returns empty so that the QQ number is not displayed as the nickname.

</details>