### PR TITLE
fix(comments): apply spam filter to pinned comments

### DIFF
--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -292,13 +292,14 @@ async function commentGet (event) {
     let top = []
     if (!config.TOP_DISABLED && !event.before) {
       // 查询置顶评论
-      query = {
-        ...condition,
+      const topCondition = {
+        url: condition.url,
+        rid: condition.rid,
         top: true
       }
       top = await db
         .collection('comment')
-        .where(query)
+        .where(getCommentQuery({ condition: topCondition, uid, isAdminUser }))
         .orderBy('updated', 'desc')
         .get()
       // 合并置顶评论和非置顶评论

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -332,14 +332,15 @@ async function commentGet (event) {
     let top = []
     if (!config.TOP_DISABLED && !event.before) {
       // 查询置顶评论
-      query = {
-        ...condition,
+      const topCondition = {
+        url: condition.url,
+        rid: condition.rid,
         top: true
       }
       top = db
         .getCollection('comment')
         .chain()
-        .find(query)
+        .find(getCommentQuery({ condition: topCondition, uid, isAdminUser }))
         .compoundsort([['created', true]])
         .data()
       // 合并置顶评论和非置顶评论

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -322,13 +322,14 @@ async function commentGet (event) {
     let top = []
     if (!config.TOP_DISABLED && !event.before) {
       // 查询置顶评论
-      query = {
-        ...condition,
+      const topCondition = {
+        url: condition.url,
+        rid: condition.rid,
         top: true
       }
       top = await db
         .collection('comment')
-        .find(query)
+        .find(getCommentQuery({ condition: topCondition, uid, isAdminUser }))
         .sort({ created: -1 })
         .toArray()
       // 合并置顶评论和非置顶评论

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -332,13 +332,14 @@ async function commentGet (event) {
     let top = []
     if (!config.TOP_DISABLED && !event.before) {
       // 查询置顶评论
-      query = {
-        ...condition,
+      const topCondition = {
+        url: condition.url,
+        rid: condition.rid,
         top: true
       }
       top = await db
         .collection('comment')
-        .find(query)
+        .find(getCommentQuery({ condition: topCondition, uid, isAdminUser }))
         .sort({ created: -1 })
         .toArray()
       // 合并置顶评论和非置顶评论


### PR DESCRIPTION
## Summary

Fixes #297

Pinned root comments were fetched with a plain `{ ...condition, top: true }` query that skipped `getCommentQuery`, so hidden (`isSpam`) comments could still appear to visitors when pinned.

This applies the same visibility filter used for regular comments across CloudBase, Vercel, and self-hosted backends.

## Test plan

- [ ] Pin a hidden comment as admin — visitors should not see it
- [ ] Pin a visible comment — visitors should still see it at the top
- [ ] Admin should still see hidden pinned comments they own / via admin rules

## Summary by Sourcery

错误修复：
- 确保在 CloudBase、Vercel、Mongo 和自托管后端中，置顶评论与普通评论遵循相同的可见性和垃圾信息过滤规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure pinned comments respect the same visibility and spam filters as regular comments in CloudBase, Vercel, Mongo, and self-hosted backends.

</details>