### PR TITLE
fix(client): update twikoo_visitors on init

### DIFF
--- a/src/client/main.all.js
+++ b/src/client/main.all.js
@@ -1,7 +1,7 @@
 import { version } from './version'
 import { install } from './utils/tcb'
 import { render } from './view'
-import { setLanguage, isUrl, getCommentsCountApi, getRecentCommentsApi } from './utils'
+import { setLanguage, isUrl, getCommentsCountApi, getRecentCommentsApi, getVisitorsCountApi, updateVisitorsCount } from './utils'
 import cloudbase from '@cloudbase/js-sdk/app'
 import '@cloudbase/js-sdk/auth'
 import '@cloudbase/js-sdk/functions'
@@ -15,6 +15,7 @@ async function init (options = {}) {
   const tcb = isUrl(options.envId) ? null : await initTcb(options)
   setLanguage(options)
   render(tcb, options)
+  await updateVisitorsCount(tcb, options)
 }
 
 async function getCommentsCount (options = {}) {
@@ -27,10 +28,16 @@ async function getRecentComments (options = {}) {
   return await getRecentCommentsApi(tcb, options)
 }
 
+async function getVisitorsCount (options = {}) {
+  const tcb = isUrl(options.envId) ? null : await initTcb(options)
+  return await getVisitorsCountApi(tcb, options)
+}
+
 export default init
 export {
   version,
   init,
   getCommentsCount,
-  getRecentComments
+  getRecentComments,
+  getVisitorsCount
 }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,7 +1,7 @@
 import { version } from './version'
 import { install } from './utils/tcb'
 import { render } from './view'
-import { setLanguage, logger, isUrl, getCommentsCountApi, getRecentCommentsApi } from './utils'
+import { setLanguage, logger, isUrl, getCommentsCountApi, getRecentCommentsApi, updateVisitorsCount } from './utils'
 
 async function initTcb (options) {
   if (typeof cloudbase === 'undefined') {
@@ -16,6 +16,7 @@ async function init (options = {}) {
   const tcb = isUrl(options.envId) ? null : await initTcb(options)
   setLanguage(options)
   render(tcb, options)
+  await updateVisitorsCount(tcb, options)
 }
 
 async function getCommentsCount (options = {}) {
@@ -28,10 +29,16 @@ async function getRecentComments (options = {}) {
   return await getRecentCommentsApi(tcb, options)
 }
 
+async function getVisitorsCount (options = {}) {
+  const tcb = isUrl(options.envId) ? null : await initTcb(options)
+  return await getVisitorsCountApi(tcb, options)
+}
+
 export default init
 export {
   version,
   init,
   getCommentsCount,
-  getRecentComments
+  getRecentComments,
+  getVisitorsCount
 }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,7 +1,7 @@
 import { version } from './version'
 import { install } from './utils/tcb'
 import { render } from './view'
-import { setLanguage, logger, isUrl, getCommentsCountApi, getRecentCommentsApi, updateVisitorsCount } from './utils'
+import { setLanguage, logger, isUrl, getCommentsCountApi, getRecentCommentsApi, getVisitorsCountApi, updateVisitorsCount } from './utils'
 
 async function initTcb (options) {
   if (typeof cloudbase === 'undefined') {

--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -122,6 +122,36 @@ const getHref = (href) => {
   return window.TWIKOO_MAGIC_HREF ?? href ?? window.location.href
 }
 
+const isLocalhost = () => {
+  return ['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1
+}
+
+const getVisitorsCountApi = async (tcb, options = {}) => {
+  const result = await call(tcb, 'COUNTER_GET', {
+    envId: options.envId,
+    funcName: options.funcName,
+    url: getUrl(options.path),
+    href: getHref(options.href),
+    title: options.title ?? document.title
+  })
+  return result.result
+}
+
+const updateVisitorsCount = async (tcb, options = {}) => {
+  const counterEl = document.getElementById('twikoo_visitors')
+  if (!counterEl || isLocalhost()) return null
+  try {
+    const counter = await getVisitorsCountApi(tcb, options)
+    if (counter.time || counter.time === 0) {
+      counterEl.innerHTML = counter.time
+    }
+    return counter
+  } catch (e) {
+    logger.warn('Failed to update visitors count', e)
+    return null
+  }
+}
+
 /**
  * 读取文本文件内容
  */
@@ -201,6 +231,8 @@ export {
   initMarkedOwo,
   getCommentsCountApi,
   getRecentCommentsApi,
+  getVisitorsCountApi,
+  updateVisitorsCount,
   getUserAgent,
   getUrl,
   getHref,

--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -121,10 +121,9 @@ const getUrl = (path) => {
 const getHref = (href) => {
   return window.TWIKOO_MAGIC_HREF ?? href ?? window.location.href
 }
+const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
 
-const isLocalhost = () => {
-  return ['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1
-}
+const isLocalhost = () => LOCALHOST_HOSTNAMES.has(window.location.hostname)
 
 const getVisitorsCountApi = async (tcb, options = {}) => {
   const result = await call(tcb, 'COUNTER_GET', {

--- a/src/client/view/components/TkFooter.vue
+++ b/src/client/view/components/TkFooter.vue
@@ -7,35 +7,12 @@
 
 <script>
 import { version } from '../../version'
-import { call, getUrl, getHref } from '../../utils'
 
 export default {
   data () {
     return {
-      version,
-      counter: {}
+      version
     }
-  },
-  methods: {
-    async getCounter () {
-      const counterEl = document.getElementById('twikoo_visitors')
-      if (!counterEl) return
-      if (['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1) return
-      const url = getUrl(this.$twikoo.path)
-      const href = getHref(this.$twikoo.href)
-      const result = await call(this.$tcb, 'COUNTER_GET', {
-        url,
-        href,
-        title: document.title
-      })
-      this.counter = result.result
-      if (this.counter.time || this.counter.time === 0) {
-        counterEl.innerHTML = this.counter.time
-      }
-    }
-  },
-  mounted () {
-    this.getCounter()
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Update `#twikoo_visitors` during `twikoo.init()` instead of only from `TkFooter` mount
- Extract shared visitor counter helpers and export `getVisitorsCount()` API

## Problem
Pages that include `<span id="twikoo_visitors">` expect the count to be filled after `twikoo.init()`, but the counter was only fetched from `TkFooter` lifecycle, which is easy to miss or race with external placement of the element.

## Test plan
- [ ] Add `#twikoo_visitors` to a page and call `twikoo.init({ envId, el })`; verify count updates
- [ ] Call `twikoo.getVisitorsCount({ envId, path, href })` without rendering comments; verify API returns counter data

Fixes #834

## Summary by Sourcery

在客户端初始化期间更新访客计数器的处理逻辑，并暴露可复用的访客数量 API。

新功能：
- 暴露公开的 `getVisitorsCount` API，用于在不渲染评论的情况下获取访客计数数据。

错误修复：
- 确保 `twikoo.init` 过程中会更新 `#twikoo_visitors`，使页面在初始化后能够可靠地显示访客数量。

改进：
- 将访客计数器逻辑重构到共享工具中，包括本地主机（localhost）检测和可复用的 `updateVisitorsCount` 辅助方法，并从 `TkFooter` 中移除页脚特定的计数器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update visitor counter handling to run during client initialization and expose a reusable visitors count API.

New Features:
- Expose a public getVisitorsCount API for retrieving visitor counter data without rendering comments.

Bug Fixes:
- Ensure #twikoo_visitors is updated as part of twikoo.init so pages reliably display visitor counts after initialization.

Enhancements:
- Refactor visitor counter logic into shared utilities, including localhost detection and a reusable updateVisitorsCount helper, and remove footer-specific counter handling from TkFooter.

</details>