### PR TITLE
feat(client): support prefill nick, mail, link and avatar on init

### DIFF
--- a/src/client/view/components/TkMetaInput.vue
+++ b/src/client/view/components/TkMetaInput.vue
@@ -38,7 +38,8 @@ export default {
       metaData: {
         nick: '',
         mail: '',
-        link: ''
+        link: '',
+        avatar: ''
       }
     }
   },
@@ -65,6 +66,14 @@ export default {
   },
   methods: {
     t,
+    applyPrefill () {
+      const prefill = this.$twikoo?.prefill
+      if (!prefill || typeof prefill !== 'object') return
+      if (prefill.nick) this.metaData.nick = prefill.nick
+      if (prefill.mail) this.metaData.mail = prefill.mail
+      if (prefill.link) this.metaData.link = prefill.link
+      if (prefill.avatar) this.metaData.avatar = prefill.avatar
+    },
     initMeta () {
       const mStr = localStorage.getItem('twikoo')
       if (mStr) {
@@ -72,8 +81,10 @@ export default {
         this.metaData.nick = metaData.nick
         this.metaData.mail = metaData.mail
         this.metaData.link = metaData.link
+        if (metaData.avatar) this.metaData.avatar = metaData.avatar
       }
-      this.updateMeta()
+      this.applyPrefill()
+      this.onMetaChange()
     },
     updateMeta () {
       localStorage.setItem('twikoo', JSON.stringify(this.metaData))

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tk-submit tk-fade-in" ref="tk-submit">
     <div class="tk-row">
-      <tk-avatar :config="config" :mail="mail" :nick="nick" />
+      <tk-avatar :config="config" :mail="mail" :nick="nick" :avatar="avatar" />
       <div class="tk-col">
         <tk-meta-input :nick="nick" :mail="mail" :link="link" @update="onMetaUpdate" :config="config" />
         <el-input class="tk-input"
@@ -99,6 +99,7 @@ export default {
       nick: '',
       mail: '',
       link: '',
+      avatar: '',
       turnstileLoad: null,
       geeTestLoad: null,
       geeTestCaptchaObj: null,
@@ -285,6 +286,7 @@ export default {
       this.nick = updates.meta.nick
       this.mail = updates.meta.mail
       this.link = updates.meta.link
+      if (updates.meta.avatar) this.avatar = updates.meta.avatar
       this.isMetaValid = updates.valid
     },
     cancel () {


### PR DESCRIPTION
## Summary
- Add `twikoo.init({ prefill: { nick, mail, link, avatar } })` to pre-populate comment meta fields
- Run the normal meta change validation path so avatar preview and the send button state update correctly

## Problem
Manually setting input values does not trigger Twikoo's meta validation, leaving the send button disabled until the user edits fields again.

## Usage
```js
twikoo.init({
  envId: 'your-env-id',
  el: '#tcomment',
  prefill: {
    nick: oaUsername,
    mail: `${oaUsername}@inner.com`,
    avatar: `https://inner.com/photo/${oaUsername}.png`
  }
})
```

Fixes #841

## 由 Sourcery 提供的摘要

为评论提交流程添加对预填用户元数据（包括头像）的初始化和传递支持。

新功能：
- 允许在客户端初始化时，通过预填配置初始化评论元字段（nick, mail, link, avatar）。

增强改进：
- 确保预填的元数据值仍会经过标准的元数据变更校验流程，从而使头像预览和提交按钮状态能够正确反映这些值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for initializing and propagating prefilled user metadata, including avatar, through the comment submission flow.

New Features:
- Allow initializing comment meta fields (nick, mail, link, avatar) from a prefill configuration on client init.

Enhancements:
- Ensure prefilled meta values run through the standard meta-change validation path so avatar preview and submit button state reflect them correctly.

</details>