### PR TITLE
feat(init): support pageSize option for comment pagination

### DIFF
--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -121,7 +121,9 @@ export default {
     },
     async getComments (event) {
       try {
-        const comments = await call(this.$tcb, 'COMMENT_GET', event)
+        const { pageSize } = this.$twikoo
+        const payload = pageSize != null ? { ...event, pageSize } : event
+        const comments = await call(this.$tcb, 'COMMENT_GET', payload)
         if (comments && comments.result && comments.result.data) {
           this.comments = event.before ? this.comments.concat(comments.result.data) : comments.result.data
           this.showExpand = comments.result.more

--- a/src/server/eo-pages/node-functions/index.js
+++ b/src/server/eo-pages/node-functions/index.js
@@ -415,7 +415,14 @@ async function commentGet (event, db, accessToken) {
     validate(event, ['url'])
     const uid = accessToken
     const isAdminUser = isAdmin(accessToken)
-    const limit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    const defaultLimit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    let limit = defaultLimit
+    if (event.pageSize != null) {
+      const parsed = parseInt(event.pageSize)
+      if (!Number.isNaN(parsed)) {
+        limit = Math.min(Math.max(parsed, 1), 100)
+      }
+    }
     const sort = event.sort || 'newest'
     let more = false
 

--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -242,7 +242,14 @@ async function commentGet (event) {
     validate(event, ['url'])
     const uid = await auth.getEndUserInfo().userInfo.uid
     const isAdminUser = await isAdmin()
-    const limit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    const defaultLimit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    let limit = defaultLimit
+    if (event.pageSize != null) {
+      const parsed = parseInt(event.pageSize)
+      if (!Number.isNaN(parsed)) {
+        limit = Math.min(Math.max(parsed, 1), 100)
+      }
+    }
     const sort = event.sort || 'newest'
     let more = false
     let condition

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -283,7 +283,14 @@ async function commentGet (event) {
     validate(event, ['url'])
     const uid = event.accessToken
     const isAdminUser = isAdmin(event.accessToken)
-    const limit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    const defaultLimit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    let limit = defaultLimit
+    if (event.pageSize != null) {
+      const parsed = parseInt(event.pageSize)
+      if (!Number.isNaN(parsed)) {
+        limit = Math.min(Math.max(parsed, 1), 100)
+      }
+    }
     const sort = event.sort || 'newest'
     let more = false
     let condition

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -273,7 +273,14 @@ async function commentGet (event) {
     validate(event, ['url'])
     const uid = event.accessToken
     const isAdminUser = isAdmin(event.accessToken)
-    const limit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    const defaultLimit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    let limit = defaultLimit
+    if (event.pageSize != null) {
+      const parsed = parseInt(event.pageSize)
+      if (!Number.isNaN(parsed)) {
+        limit = Math.min(Math.max(parsed, 1), 100)
+      }
+    }
     const sort = event.sort || 'newest'
     let more = false
     let condition

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -283,7 +283,14 @@ async function commentGet (event) {
     validate(event, ['url'])
     const uid = getUid()
     const isAdminUser = isAdmin()
-    const limit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    const defaultLimit = parseInt(config.COMMENT_PAGE_SIZE) || 8
+    let limit = defaultLimit
+    if (event.pageSize != null) {
+      const parsed = parseInt(event.pageSize)
+      if (!Number.isNaN(parsed)) {
+        limit = Math.min(Math.max(parsed, 1), 100)
+      }
+    }
     const sort = event.sort || 'newest'
     let more = false
     let condition


### PR DESCRIPTION
## Summary
Add `pageSize` to `twikoo.init()` options so comment widgets can control how many root comments load per page.

## Problem
Fixes #828. `getRecentComments({ pageSize })` already works, but `twikoo.init({ pageSize })` had no effect — `COMMENT_GET` always used server config `COMMENT_PAGE_SIZE` (default 8).

## Changes
- Client: forward `pageSize` from init options in `TkComments` `COMMENT_GET` requests
- Server (all backends): honor `event.pageSize` when provided, clamped to 1–100; otherwise keep existing config default

## Test plan
- [ ] `twikoo.init({ pageSize: 20, ... })` loads up to 20 root comments on first page
- [ ] Expand/load-more still works with the configured page size
- [ ] Invalid or missing `pageSize` falls back to server config default

## Summary by Sourcery

通过初始化选项为每个小组件提供可配置的评论分页大小，并确保在获取评论时，所有后端都遵守请求的分页大小。

New Features:
- 允许评论小组件通过 `twikoo.init` 选项指定自定义分页大小，并在 `COMMENT_GET` 请求中传递该参数。

Bug Fixes:
- 确保所有后端的 `COMMENT_GET` 处理程序都会遵守可选的 `pageSize` 参数，并将其限制在安全范围内，而不是始终使用服务器默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable comment page size per widget via the init options and ensure all backends respect the requested page size when fetching comments.

New Features:
- Allow comment widgets to specify a custom page size via twikoo.init options and forward it in COMMENT_GET requests.

Bug Fixes:
- Ensure COMMENT_GET handlers across all backends honor an optional pageSize parameter, clamped to a safe range, instead of always using the server default.

</details>