### PR TITLE
add custom twikoo host config for self-hosted

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -292,6 +292,7 @@ lambda_function_url = "https://axtoiiithbcexamplegq7ozalu0cnkii.lambda-url.us-we
 | `MONGODB_URI` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `MONGO_URL` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `TWIKOO_DATA` | lokijs 数据库存储路径 | `./data` |
+| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `null` |
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -292,7 +292,7 @@ lambda_function_url = "https://axtoiiithbcexamplegq7ozalu0cnkii.lambda-url.us-we
 | `MONGODB_URI` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `MONGO_URL` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `TWIKOO_DATA` | lokijs 数据库存储路径 | `./data` |
-| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `null` |
+| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1）,设置该值则会忽略 TWIKOO_LOCALHOST_ONLY，默认值为 null 但实际行为会回退到 `::` | `null` |
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |

--- a/src/server/pkg/.env
+++ b/src/server/pkg/.env
@@ -9,6 +9,9 @@ MONGO_URL=
 # lokijs 数据库存储路径
 TWIKOO_DATA='./data'
 
+# Host IP
+TWIKOO_HOST=
+
 # 端口号
 TWIKOO_PORT=8080
 

--- a/src/server/self-hosted/README.md
+++ b/src/server/self-hosted/README.md
@@ -19,6 +19,7 @@ tkserver
 | `MONGODB_URI` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `MONGO_URL` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `TWIKOO_DATA` | lokijs 数据库存储路径 | `./data` |
+| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `::` |
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |

--- a/src/server/self-hosted/README.md
+++ b/src/server/self-hosted/README.md
@@ -19,7 +19,7 @@ tkserver
 | `MONGODB_URI` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `MONGO_URL` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `TWIKOO_DATA` | lokijs 数据库存储路径 | `./data` |
-| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `null` |
+| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1）,设置该值则会忽略 TWIKOO_LOCALHOST_ONLY，默认值为 null 但实际行为会回退到 `::` | `null` |
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |

--- a/src/server/self-hosted/README.md
+++ b/src/server/self-hosted/README.md
@@ -19,7 +19,7 @@ tkserver
 | `MONGODB_URI` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `MONGO_URL` | MongoDB 数据库连接字符串，不传则使用 lokijs | `null` |
 | `TWIKOO_DATA` | lokijs 数据库存储路径 | `./data` |
-| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `::` |
+| `TWIKOO_HOST` | 自定义监听的主机名或IP地址（例如 0.0.0.0 或 127.0.0.1） | `null` |
 | `TWIKOO_PORT` | 端口号 | `8080` |
 | `TWIKOO_THROTTLE` | IP 请求限流，当同一 IP 短时间内请求次数超过阈值将对该 IP 返回错误 | `250` |
 | `TWIKOO_LOCALHOST_ONLY` | 为`true`时只监听本地请求，使得 nginx 等服务器反代之后不暴露原始端口 | `null` |

--- a/src/server/self-hosted/server.js
+++ b/src/server/self-hosted/server.js
@@ -32,7 +32,7 @@ server.on('request', async function (request, response) {
 })
 
 const port = parseInt(process.env.TWIKOO_PORT) || 8080
-const host = process.env.TWIKOO_LOCALHOST_ONLY === 'true' ? 'localhost' : '::'
+const host = process.env.TWIKOO_HOST || (process.env.TWIKOO_LOCALHOST_ONLY === 'true' ? 'localhost' : '::')
 
 server.listen(port, host, function () {
   logger.info(`Twikoo is using ${dbUrl ? 'mongo' : 'loki'} database`)


### PR DESCRIPTION
## 动机
添加环境变量 TWIKOO_HOST 支持指定 server binding 的 ip 地址

原因：在支持 IPV6 的vps上，禁用IPv6后（gemini对IPV6的来源流量审查特别严格），tkserver  binding `::` 会启动失败

## 修改前：
```bash
5/26/2026, 2:40:18 AM Twikoo: Connecting to database...
node:events:486
      throw er; // Unhandled 'error' event
      ^

Error: listen EAFNOSUPPORT: address family not supported :::8080
    at Server.setupListenHandle [as _listen2] (node:net:1918:21)
    at listenInCluster (node:net:1997:12)
    at node:net:2206:7
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1976:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
  code: 'EAFNOSUPPORT',
  errno: -97,
  syscall: 'listen',
  address: '::',
  port: 8080
}

Node.js v24.11.1

```

## 修改后：
启动命令：
```bash
export TWIKOO_HOST=0.0.0.0
nohup tkserver > tkserver.log 2>&1 &
```
输出：
```bash
5/26/2026, 3:17:57 AM Twikoo: Twikoo database stored at /root/workspace/twikoo/data
5/26/2026, 3:17:57 AM Twikoo: Connecting to database...
5/26/2026, 3:17:57 AM Twikoo: Twikoo is using loki database
5/26/2026, 3:17:57 AM Twikoo: Twikoo function started on host 0.0.0.0 port 8080
5/26/2026, 3:17:57 AM Twikoo: Connected to database

```

## Summary by Sourcery

为自托管的 Twikoo 服务器新增可配置的主机绑定，并在文档中说明新的环境变量。

新特性：
- 引入 `TWIKOO_HOST` 环境变量，用于自定义自托管服务器监听的主机/IP 地址；当设置该变量时，其优先级高于 `TWIKOO_LOCALHOST_ONLY`。

文档：
- 在后端和自托管服务器文档中补充 `TWIKOO_HOST` 环境变量的说明，包括其行为和使用示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable host binding for the self-hosted Twikoo server and document the new environment variable.

New Features:
- Introduce TWIKOO_HOST environment variable to customize the host/IP address the self-hosted server listens on, taking precedence over TWIKOO_LOCALHOST_ONLY when set.

Documentation:
- Document the TWIKOO_HOST environment variable in backend and self-hosted server documentation, including its behavior and examples.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为自托管的 Twikoo 服务器新增可配置的主机绑定，并在文档中说明新的环境变量。

新特性：
- 引入 `TWIKOO_HOST` 环境变量，用于自定义自托管服务器监听的主机/IP 地址；当设置该变量时，其优先级高于 `TWIKOO_LOCALHOST_ONLY`。

文档：
- 在后端和自托管服务器文档中补充 `TWIKOO_HOST` 环境变量的说明，包括其行为和使用示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable host binding for the self-hosted Twikoo server and document the new environment variable.

New Features:
- Introduce TWIKOO_HOST environment variable to customize the host/IP address the self-hosted server listens on, taking precedence over TWIKOO_LOCALHOST_ONLY when set.

Documentation:
- Document the TWIKOO_HOST environment variable in backend and self-hosted server documentation, including its behavior and examples.

</details>

</details>