### PR TITLE
fix: 修复 Docker 正常停止时间（10秒->0.5秒）

### DIFF
--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -69,6 +69,7 @@ const TWIKOO_REQ_TIMES_CLEAR_TIME = parseInt(process.env.TWIKOO_REQ_TIMES_CLEAR_
 let db = null
 let config
 let requestTimes = {}
+let requestTimesTimer = null
 
 connectToDatabase()
 
@@ -1065,8 +1066,33 @@ function getIp (request) {
   return getUserIP(request)
 }
 
+async function closeDatabase () {
+  if (!db) return
+  await new Promise((resolve, reject) => {
+    db.saveDatabase((err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+  db.close()
+  db = null
+}
+
+async function shutdown () {
+  if (requestTimesTimer) {
+    clearInterval(requestTimesTimer)
+    requestTimesTimer = null
+  }
+  await closeDatabase()
+}
+
 function clearRequestTimes () {
   requestTimes = {}
 }
 
-setInterval(clearRequestTimes, TWIKOO_REQ_TIMES_CLEAR_TIME)
+requestTimesTimer = setInterval(clearRequestTimes, TWIKOO_REQ_TIMES_CLEAR_TIME)
+
+module.exports.shutdown = shutdown

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -1068,17 +1068,20 @@ function getIp (request) {
 
 async function closeDatabase () {
   if (!db) return
-  await new Promise((resolve, reject) => {
-    db.saveDatabase((err) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
+  try {
+    await new Promise((resolve, reject) => {
+      db.saveDatabase((err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
     })
-  })
-  db.close()
-  db = null
+  } finally {
+    db.close()
+    db = null
+  }
 }
 
 async function shutdown () {

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -66,6 +66,8 @@ const TWIKOO_REQ_TIMES_CLEAR_TIME = parseInt(process.env.TWIKOO_REQ_TIMES_CLEAR_
 let db = null
 let config
 let requestTimes = {}
+let client = null
+let requestTimesTimer = null
 
 module.exports = async (request, response) => {
   let accessToken
@@ -225,7 +227,7 @@ async function connectToDatabase (uri) {
   if (!uri) throw new Error('未设置环境变量 MONGODB_URI | MONGO_URL')
   // If no connection is cached, create a new one
   logger.info('Connecting to database...')
-  const client = await MongoClient.connect(uri, {})
+  client = await MongoClient.connect(uri, {})
   // Select the database through the connection,
   // using the database path of the connection string
   const dbName = (new URL(uri)).pathname.substring(1) || 'twikoo'
@@ -1037,8 +1039,22 @@ function getIp (request) {
   return getUserIP(request)
 }
 
+async function shutdown () {
+  if (requestTimesTimer) {
+    clearInterval(requestTimesTimer)
+    requestTimesTimer = null
+  }
+  if (client) {
+    await client.close()
+    client = null
+    db = null
+  }
+}
+
 function clearRequestTimes () {
   requestTimes = {}
 }
 
-setInterval(clearRequestTimes, TWIKOO_REQ_TIMES_CLEAR_TIME)
+requestTimesTimer = setInterval(clearRequestTimes, TWIKOO_REQ_TIMES_CLEAR_TIME)
+
+module.exports.shutdown = shutdown

--- a/src/server/self-hosted/server.js
+++ b/src/server/self-hosted/server.js
@@ -6,6 +6,7 @@ const logger = require('twikoo-func/utils/logger')
 const dbUrl = process.env.MONGODB_URI || process.env.MONGO_URL || null
 const twikoo = dbUrl ? require('./mongo') : require('./index')
 const server = http.createServer()
+let isShuttingDown = false
 
 server.on('request', async function (request, response) {
   try {
@@ -38,3 +39,35 @@ server.listen(port, host, function () {
   logger.info(`Twikoo is using ${dbUrl ? 'mongo' : 'loki'} database`)
   logger.info(`Twikoo function started on host ${host} port ${port}`)
 })
+
+async function shutdown (signal) {
+  if (isShuttingDown) return
+  isShuttingDown = true
+  logger.info(`Received ${signal}, shutting down Twikoo server...`)
+  await new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+  if (typeof twikoo.shutdown === 'function') {
+    await twikoo.shutdown()
+  }
+  logger.info('Twikoo server stopped')
+}
+
+async function handleSignal (signal) {
+  try {
+    await shutdown(signal)
+    process.exit(0)
+  } catch (e) {
+    logger.error('Twikoo server shutdown failed:', e)
+    process.exit(1)
+  }
+}
+
+process.on('SIGTERM', () => handleSignal('SIGTERM'))
+process.on('SIGINT', () => handleSignal('SIGINT'))

--- a/src/server/self-hosted/server.js
+++ b/src/server/self-hosted/server.js
@@ -6,9 +6,20 @@ const logger = require('twikoo-func/utils/logger')
 const dbUrl = process.env.MONGODB_URI || process.env.MONGO_URL || null
 const twikoo = dbUrl ? require('./mongo') : require('./index')
 const server = http.createServer()
+const sockets = new Set()
+const TWIKOO_SHUTDOWN_TIMEOUT = parseInt(process.env.TWIKOO_SHUTDOWN_TIMEOUT) || 5000
 let isShuttingDown = false
+let shuttingDownPromise = null
 
 server.on('request', async function (request, response) {
+  if (isShuttingDown) {
+    response.writeHead(503, {
+      Connection: 'close',
+      'Content-Type': 'application/json'
+    })
+    response.end(JSON.stringify({ code: 503, message: 'Twikoo server is shutting down' }))
+    return
+  }
   try {
     const buffers = []
     for await (const chunk of request) {
@@ -32,6 +43,11 @@ server.on('request', async function (request, response) {
   return await twikoo(request, response)
 })
 
+server.on('connection', (socket) => {
+  sockets.add(socket)
+  socket.on('close', () => sockets.delete(socket))
+})
+
 const port = parseInt(process.env.TWIKOO_PORT) || 8080
 const host = process.env.TWIKOO_HOST || (process.env.TWIKOO_LOCALHOST_ONLY === 'true' ? 'localhost' : '::')
 
@@ -40,11 +56,8 @@ server.listen(port, host, function () {
   logger.info(`Twikoo function started on host ${host} port ${port}`)
 })
 
-async function shutdown (signal) {
-  if (isShuttingDown) return
-  isShuttingDown = true
-  logger.info(`Received ${signal}, shutting down Twikoo server...`)
-  await new Promise((resolve, reject) => {
+function closeServer () {
+  return new Promise((resolve, reject) => {
     server.close((err) => {
       if (err) {
         reject(err)
@@ -53,19 +66,58 @@ async function shutdown (signal) {
       }
     })
   })
-  if (typeof twikoo.shutdown === 'function') {
-    await twikoo.shutdown()
+}
+
+function destroySockets () {
+  for (const socket of sockets) {
+    socket.destroy()
+  }
+}
+
+async function shutdownWithTimeout () {
+  let timeoutId
+  const closeTask = closeServer()
+  const timeoutTask = new Promise((resolve) => {
+    timeoutId = setTimeout(() => {
+      logger.warn(`Twikoo server shutdown timed out after ${TWIKOO_SHUTDOWN_TIMEOUT}ms, destroying open connections`)
+      destroySockets()
+      resolve()
+    }, TWIKOO_SHUTDOWN_TIMEOUT)
+  })
+  await Promise.race([closeTask, timeoutTask])
+  clearTimeout(timeoutId)
+  await closeTask
+}
+
+async function runShutdown (signal) {
+  isShuttingDown = true
+  logger.info(`Received ${signal}, shutting down Twikoo server...`)
+  try {
+    await shutdownWithTimeout()
+  } catch (e) {
+    logger.error('Twikoo HTTP server shutdown failed:', e)
+  } finally {
+    if (typeof twikoo.shutdown === 'function') {
+      await twikoo.shutdown()
+    }
   }
   logger.info('Twikoo server stopped')
+}
+
+async function shutdown (signal) {
+  if (!shuttingDownPromise) {
+    shuttingDownPromise = runShutdown(signal)
+  }
+  return await shuttingDownPromise
 }
 
 async function handleSignal (signal) {
   try {
     await shutdown(signal)
-    process.exit(0)
+    process.exitCode = 0
   } catch (e) {
     logger.error('Twikoo server shutdown failed:', e)
-    process.exit(1)
+    process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
## 原因

就是用 Docker 关闭时，发现 Docker 发送终止信号后，Node 进程没有处理信号，导致无法正常退出，最后被默认 10 秒超时强制杀死。

## Summary
- handle SIGTERM and SIGINT in the self-hosted HTTP server
- close the HTTP server before process exit
- clear request throttling timers and close LokiJS or MongoDB resources during shutdown

## Verification
- `./node_modules/.bin/eslint.cmd src/server/self-hosted/server.js src/server/self-hosted/index.js src/server/self-hosted/mongo.js --ignore-path .eslintignore`
- `node -c src/server/self-hosted/server.js; node -c src/server/self-hosted/index.js; node -c src/server/self-hosted/mongo.js`
- built a local Docker image from `src/server/self-hosted`; `docker stop` completed in ~0.43s and logged graceful SIGTERM shutdown

## Summary by Sourcery

为自托管的 Twikoo 服务器实现优雅关闭机制，使其在收到进程终止信号时能够正确停止 HTTP 服务器并释放数据库资源。

Bug Fixes:
- 通过处理 SIGTERM 和 SIGINT，在进程退出前先关闭 HTTP 服务器，防止自托管服务器被突然终止。
- 确保在服务器关闭过程中，LokiJS 和 MongoDB 连接以及请求限流计时器都能被正确清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement graceful shutdown for the self-hosted Twikoo server to properly stop the HTTP server and release database resources on process termination signals.

Bug Fixes:
- Prevent abrupt termination of the self-hosted server by handling SIGTERM and SIGINT and closing the HTTP server before process exit.
- Ensure LokiJS and MongoDB connections and request throttling timers are properly cleaned up during server shutdown.

</details>