### PR TITLE
fix(edgeone): 修复 MAX_REQUEST_TIMES 被版本号替换误伤

### DIFF
--- a/src/server/eo-pages/cloud-functions/index.js
+++ b/src/server/eo-pages/cloud-functions/index.js
@@ -56,8 +56,8 @@ import { uploadImage } from 'twikoo-func/utils/image'
 import logger from 'twikoo-func/utils/logger'
 import constants from 'twikoo-func/utils/constants'
 
-const { RES_CODE,1.7.12EQUEST_TIMES } = constants
-const VERSION = '1.7.11'
+const { RES_CODE, MAX_REQUEST_TIMES } = constants
+const VERSION = '1.7.12'
 const EO_SMTP_BRIDGE_PATH = '/smtp'
 const SMTP_BRIDGE_PROBE_TIMEOUT_MS = 5000
 


### PR DESCRIPTION
## 修复 EdgeOne Pages 部署时的语法解析错误

提交 `19d27ff8efd4dff3f552fbc4a63554502c1fe28c` 中，版本号替换误将 `MAX_REQUEST_TIMES` 替换为 `1.7.12EQUEST_TIMES`，导致 EdgeOne Pages 部署时 Babel 解析 `cloud-functions/index.js` 失败。

### 变更

- 修复 `1.7.12EQUEST_TIMES` → `MAX_REQUEST_TIMES`
- 将 `VERSION` 同步为 `1.7.12`

### 影响

修复后 `cloud-functions/index.js` 可以被 EdgeOne CLI 正常解析，避免部署阶段出现 `InvalidOrMissingExponent` 语法错误。