### PR TITLE
fix(comment): keep pagination state after replying to a comment

### DIFF
--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -78,7 +78,8 @@
             :config="config"
             @expand="onExpand"
             @load="onLoad"
-            @reply="onReplyReply" />
+            @reply="onReplyReply"
+            @refreshed="onRefreshed" />
       </div>
       <div class="tk-expand-wrap" v-if="showExpand && !replying">
         <div class="tk-expand" @click="onExpand">{{ t('COMMENT_EXPAND') }}</div>
@@ -295,16 +296,21 @@ export default {
       this.$emit('reply', '')
     },
     onLoad () {
-      if (this.comment.replies.length > 0) {
-        this.$refs['tk-replies'].lastElementChild.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        })
-      }
       this.pid = ''
       this.$emit('reply', '')
       this.$emit('load')
       this.onExpand()
+    },
+    onRefreshed () {
+      this.$emit('refreshed')
+      this.$nextTick(() => {
+        if (this.comment.replies && this.comment.replies.length > 0 && this.$refs['tk-replies']) {
+          this.$refs['tk-replies'].lastElementChild.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+          })
+        }
+      })
     },
     onExpand () {
       this.isExpanded = true

--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -103,16 +103,15 @@ export default {
     },
     async refreshPreservingState () {
       this.loading = true
-      const url = getUrl(this.$twikoo.path)
-      await this.getComments({ url, sort: this.currentSort })
-      for (let i = 1; i < this.loadedPages; i++) {
-        const before = this.comments
-          .filter((item) => !item.top)
-          .map((item) => item.created)
-          .sort((a, b) => a - b)[0]
-        await this.getComments({ url, before, sort: this.currentSort })
+      try {
+        const url = getUrl(this.$twikoo.path)
+        await this.getComments({ url, sort: this.currentSort })
+        for (let i = 1; i < this.loadedPages; i++) {
+          if (!(await this.loadNextPage(url))) break
+        }
+      } finally {
+        this.loading = false
       }
-      this.loading = false
       this.$emit('refreshed')
     },
     setSort (sort) {
@@ -126,13 +125,25 @@ export default {
       if (this.loadingMore) return
       this.loadingMore = true
       this.loadedPages++
-      const url = getUrl(this.$twikoo.path)
-      const before = this.comments
-        .filter((item) => !item.top)
-        .map((item) => item.created)
-        .sort((a, b) => a - b)[0]
+      try {
+        const url = getUrl(this.$twikoo.path)
+        await this.loadNextPage(url)
+      } finally {
+        this.loadingMore = false
+      }
+    },
+    getOldestCreated () {
+      let min = Infinity
+      for (const item of this.comments) {
+        if (!item.top && item.created < min) min = item.created
+      }
+      return min === Infinity ? undefined : min
+    },
+    async loadNextPage (url) {
+      const before = this.getOldestCreated()
+      if (before === undefined) return false
       await this.getComments({ url, before, sort: this.currentSort })
-      this.loadingMore = false
+      return true
     },
     onCommentLoaded () {
       typeof this.$twikoo.onCommentLoaded === 'function' && this.$twikoo.onCommentLoaded()

--- a/src/client/view/components/TkComments.vue
+++ b/src/client/view/components/TkComments.vue
@@ -40,7 +40,7 @@
         :replying="replyId === comment.id"
         :config="config"
         @reply="onReply"
-        @load="initComments" />
+        @load="refreshPreservingState" />
       <div class="tk-expand-wrap" v-if="showExpand && !loading">
         <div class="tk-expand" @click="onExpand" v-loading="loadingMore">{{ t('COMMENTS_EXPAND') }}</div>
       </div>
@@ -75,6 +75,7 @@ export default {
       showExpand: true,
       count: 0,
       replyId: '',
+      loadedPages: 1,
       currentSort: 'newest',
       iconSetting,
       iconRefresh
@@ -97,17 +98,34 @@ export default {
     },
     refresh () {
       this.comments = []
+      this.loadedPages = 1
       this.initComments()
+    },
+    async refreshPreservingState () {
+      this.loading = true
+      const url = getUrl(this.$twikoo.path)
+      await this.getComments({ url, sort: this.currentSort })
+      for (let i = 1; i < this.loadedPages; i++) {
+        const before = this.comments
+          .filter((item) => !item.top)
+          .map((item) => item.created)
+          .sort((a, b) => a - b)[0]
+        await this.getComments({ url, before, sort: this.currentSort })
+      }
+      this.loading = false
+      this.$emit('refreshed')
     },
     setSort (sort) {
       if (this.currentSort === sort) return
       this.currentSort = sort
       this.comments = []
+      this.loadedPages = 1
       this.initComments()
     },
     async onExpand () {
       if (this.loadingMore) return
       this.loadingMore = true
+      this.loadedPages++
       const url = getUrl(this.$twikoo.path)
       const before = this.comments
         .filter((item) => !item.top)


### PR DESCRIPTION
## 问题 
在回复其他页的评论后，评论列表会重载回第一页，丢失已展开的分页状态。

## 原因
`TkComment` 的 `onLoad()` 在回复成功后 emit `'load'` 事件，`TkComments` 收到后调用 `initComments()`，该方法总是加载第一页（无 `before` 参数），导致已加载的后续页被丢弃。

## 修改内容
**TkComments.vue**
- 添加 `loadedPages` 跟踪已展开页数
- 新增 `refreshPreservingState()` 方法，刷新时保持分页状态
- TkComment 的 `@load` 改为调用 `refreshPreservingState`（顶层提交仍用 `initComments`）

**TkComment.vue**
- `onLoad()` 移除无效的 `scrollIntoView`（刷新前 DOM 未更新）
- 新增 `onRefreshed()`，在刷新完成后滚动到最新回复"

## Summary by Sourcery

在回复评论并刷新线程时，保留评论列表的分页和滚动行为。

Bug 修复：
- 在发布回复后保持当前的评论页和已展开的分页状态，而不是重新加载并回到第一页。

功能增强：
- 追踪已加载的评论页，并添加一个在保留分页状态的前提下重新加载评论的刷新方法。
- 将回复后的滚动行为移动到评论刷新完成之后执行，使视图能够平滑滚动到最新回复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve comment list pagination and scroll behavior when replying to comments and refreshing the thread.

Bug Fixes:
- Keep the current comments page and expanded pagination state after posting a reply instead of reloading back to the first page.

Enhancements:
- Track loaded comment pages and add a refresh method that reloads comments while preserving pagination state.
- Move reply-scroll behavior to run after comments refresh completes so the view scrolls smoothly to the latest reply.

</details>