### PR TITLE
修复 EdgeOne Pages 平台评论删除与点赞状态显示异常

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,9 @@ module.exports = [
       'src/server/pkg/dist/**',
       'src/server/pkg/patches/**',
       'src/server/pkg/web.config',
-      'src/server/eo-pages/cloud-functions/**'
+      'src/server/eo-pages/cloud-functions/ip2region-data.js',
+      'src/server/eo-pages/cloud-functions/smtp.go',
+      'src/server/eo-pages/.edgeone/**'
     ]
   },
   ...neostandard({

--- a/src/server/eo-pages/cloud-functions/index.js
+++ b/src/server/eo-pages/cloud-functions/index.js
@@ -411,6 +411,8 @@ function toCommentDto (comment, uid, replies = [], comments = [], cfg) {
     browser: displayBrowser,
     ipRegion: showRegion ? getIpRegion(comment.ip, false) : '',
     master: comment.master,
+    // Keep the legacy like field for backward compatibility.
+    // New reaction counts and user state are derived from ups/downs.
     like: comment.like ? comment.like.length : 0,
     liked: Boolean(uid && ups.includes(uid)),
     disliked: Boolean(uid && downs.includes(uid)),

--- a/src/server/eo-pages/cloud-functions/index.js
+++ b/src/server/eo-pages/cloud-functions/index.js
@@ -398,6 +398,8 @@ function toCommentDto (comment, uid, replies = [], comments = [], cfg) {
     }
   }
   const showRegion = !!cfg.SHOW_REGION && cfg.SHOW_REGION !== 'false'
+  const ups = comment.ups || []
+  const downs = comment.downs || []
   return {
     id: comment._id.toString(),
     nick: comment.nick,
@@ -410,13 +412,17 @@ function toCommentDto (comment, uid, replies = [], comments = [], cfg) {
     ipRegion: showRegion ? getIpRegion(comment.ip, false) : '',
     master: comment.master,
     like: comment.like ? comment.like.length : 0,
-    liked: comment.like ? comment.like.findIndex((item) => item === uid) > -1 : false,
-    replies: replies,
+    liked: Boolean(uid && ups.includes(uid)),
+    disliked: Boolean(uid && downs.includes(uid)),
+    ups: ups.length,
+    downs: downs.length,
+    replies,
     rid: comment.rid,
     pid: comment.pid,
     ruser: getRuser(comment.pid, comments),
     top: comment.top,
     isSpam: comment.isSpam,
+    isOwner: Boolean(uid && comment.uid === uid),
     created: comment.created,
     updated: comment.updated
   }
@@ -1036,7 +1042,7 @@ async function parseCommentData (event, req, accessToken, ip) {
     mailMd5: event.mail ? hashMethod(normalizeMail(event.mail)) : '',
     link: event.link ? event.link : '',
     ua: event.ua,
-    ip: ip,
+    ip,
     master: isBloggerMail,
     url: event.url,
     href: event.href,
@@ -1118,7 +1124,7 @@ async function checkCaptcha (event, ip) {
   const provider = config.CAPTCHA_PROVIDER
   if (provider === 'Turnstile' && config.TURNSTILE_SITE_KEY && config.TURNSTILE_SECRET_KEY) {
     await checkTurnstileCaptcha({
-      ip: ip,
+      ip,
       turnstileToken: event.turnstileToken,
       turnstileTokenSecretKey: config.TURNSTILE_SECRET_KEY
     })


### PR DESCRIPTION
修复 EdgeOne Pages 平台评论删除与点赞状态显示异常

EdgeOne Pages 的 `toCommentDto` 返回字段与标准实现不一致，缺少 `isOwner`、`ups`、`downs`、`disliked` 字段。

这会导致：

* 用户自己的评论无法显示删除按钮；
* 点赞 / 点踩计数无法正确显示；
* 点赞 / 点踩状态刷新后无法正确恢复。

实际后端逻辑中，`COMMENT_DELETE_FOR_USER` 和 `COMMENT_LIKE` 均能正常工作；问题仅出在 `COMMENT_GET` 返回的 DTO 字段不完整。

本次修复：

* 补充 `isOwner` 字段，用于前端判断是否显示用户删除按钮；
* 补充 `ups` / `downs` 字段，用于前端显示点赞 / 点踩计数；
* 补充 `disliked` 字段，用于前端恢复点踩状态；
* 将 `liked` 改为基于 `ups.includes(uid)` 判断；
* 保留旧的 `like` 字段以保持兼容。

## Summary by Sourcery

使 EdgeOne Pages 评论 DTO 与标准字段保持一致，以修复删除和点赞/点踩状态显示问题。

Bug 修复：
- 暴露 `isOwner` 标志，以便前端能够正确显示用户自己评论的删除按钮。
- 返回 `ups/downs` 计数和 `disliked` 状态，使点赞/点踩的数量和状态在刷新后能够正确保持。

增强：
- 在保留传统 `like` 计数以确保向后兼容的同时，将 `liked/disliked` 标志基于 `ups/downs` 数组。
- 收紧针对 EdgeOne Pages 云函数辅助文件和生成产物的 ESLint 忽略规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align EdgeOne Pages comment DTO with standard fields to fix deletion and like/dislike state display issues.

Bug Fixes:
- Expose isOwner flag so the frontend can correctly show the delete button for a user's own comments.
- Return ups/downs counts and disliked state so like/dislike counts and statuses persist correctly across refreshes.

Enhancements:
- Base liked/disliked flags on ups/downs arrays while keeping the legacy like count for backward compatibility.
- Tighten ESLint ignore patterns for EdgeOne Pages cloud function ancillary files and generated artifacts.

</details>