### PR TITLE
feat: 使 cap.js 人机验证支持开箱即用，无须额外配置服务端

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ db.json.*
 
 pnpm-lock.yaml
 .idea/
+.omc
 
 # macOS
 .DS_Store

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1019,26 +1019,26 @@ export default {
     'Kunci GeeTest CAPTCHA'
   ],
   [S.ACI + '_CAP_API_ENDPOINT']: [
-    'Cap 验证码 API 端点（格式：https://<实例地址>/<site_key>/）',
-    'Cap 验证码 API 端点（格式：https://<实例地址>/<site_key>/）',
-    'Cap 验证码 API 端点（格式：https://<实例地址>/<site_key>/）',
-    'Cap CAPTCHA API Endpoint (format: https://<instance_url>/<site_key>/)',
-    'Cap CAPTCHA API Endpoint (format: https://<instance_url>/<site_key>/)',
-    'Cap CAPTCHA API Endpoint (format: https://<instance_url>/<site_key>/)',
-    'Cap CAPTCHA API Endpoint (format: https://<instance_url>/<site_key>/)',
-    'Cap CAPTCHA API Endpoint (định dạng: https://<instance_url>/<site_key>/)',
-    'Endpoint API Cap CAPTCHA (format: https://<alamat_instansi>/<site_key>/)'
+    'Cap 验证码 API 端点。留空则使用内嵌 Cap（无需额外部署）；外部 Standalone 格式：https://<实例地址>/<site_key>/',
+    'Cap 验证码 API 端点。留空则使用内嵌 Cap（无需额外部署）；外部 Standalone 格式：https://<实例地址>/<site_key>/',
+    'Cap 验证码 API 端点。留空则使用内嵌 Cap（无需额外部署）；外部 Standalone 格式：https://<实例地址>/<site_key>/',
+    'Cap CAPTCHA API endpoint. Leave empty for built-in Cap (no extra server). External Standalone format: https://<instance_url>/<site_key>/',
+    'Cap CAPTCHA API endpoint. Leave empty for built-in Cap (no extra server). External Standalone format: https://<instance_url>/<site_key>/',
+    'Cap CAPTCHA API Endpoint。空欄で内蔵 Cap を使用（追加サーバー不要）。外部 Standalone 形式: https://<instance_url>/<site_key>/',
+    'Cap CAPTCHA API Endpoint. 비우면 내장 Cap 사용(추가 서버 불필요). 외부 Standalone 형식: https://<instance_url>/<site_key>/',
+    'Endpoint API Cap CAPTCHA. Để trống = Cap tích hợp (không cần server ngoài). Standalone ngoài: https://<instance_url>/<site_key>/',
+    'Endpoint API Cap CAPTCHA. Kosongkan = Cap bawaan (tanpa server ekstra). Standalone eksternal: https://<instance_url>/<site_key>/'
   ],
   [S.ACI + '_CAP_SECRET_KEY']: [
-    'Cap 验证码的 Secret Key',
-    'Cap 验证码的 Secret Key',
-    'Cap 验证码的 Secret Key',
-    'Cap CAPTCHA Secret Key',
-    'Cap CAPTCHA Secret Key',
-    'Cap CAPTCHA Secret Key',
-    'Cap CAPTCHA Secret Key',
-    'Cap CAPTCHA Secret Key',
-    'Kunci Rahasia CAPTCHA Cap'
+    'Cap Secret Key（仅外部 Standalone 需要；内嵌模式可留空）',
+    'Cap Secret Key（僅外部 Standalone 需要；內嵌模式可留空）',
+    'Cap Secret Key（僅外部 Standalone 需要；內嵌模式可留空）',
+    'Cap Secret Key (external Standalone only; leave empty for built-in)',
+    'Cap Secret Key (external Standalone only; leave empty for built-in)',
+    'Cap Secret Key（外部 Standalone のみ。内蔵時は空欄可）',
+    'Cap Secret Key (외부 Standalone 전용; 내장 모드는 비워둠)',
+    'Cap Secret Key (chỉ Standalone ngoài; để trống nếu dùng tích hợp)',
+    'Cap Secret Key (hanya Standalone eksternal; kosongkan untuk bawaan)'
   ],
   [S.ACI + '_QCLOUD_SECRET_ID']: [
     '腾讯云 secret id，用于垃圾评论检测。同时设置腾讯云和 Akismet 时，只有腾讯云会生效。注册：https://twikoo.js.org/cms.html',

--- a/src/client/view/components/TkAdminConfig.vue
+++ b/src/client/view/components/TkAdminConfig.vue
@@ -160,8 +160,8 @@ export default {
             { key: 'TURNSTILE_SECRET_KEY', desc: t('ADMIN_CONFIG_ITEM_TURNSTILE_SECRET_KEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}0x4AAAAAAAPLTmBm6gHmOnOqC1iwmU12345`, value: '', secret: true, showIf: (s) => s('CAPTCHA_PROVIDER') === 'Turnstile' },
             { key: 'GEETEST_CAPTCHA_ID', desc: t('ADMIN_CONFIG_ITEM_GEETEST_CAPTCHA_ID'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}your_captcha_id`, value: '', showIf: (s) => s('CAPTCHA_PROVIDER') === 'Geetest' },
             { key: 'GEETEST_CAPTCHA_KEY', desc: t('ADMIN_CONFIG_ITEM_GEETEST_CAPTCHA_KEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}your_captcha_key`, value: '', secret: true, showIf: (s) => s('CAPTCHA_PROVIDER') === 'Geetest' },
-            { key: 'CAP_API_ENDPOINT', desc: t('ADMIN_CONFIG_ITEM_CAP_API_ENDPOINT'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://cap.example.com/d9256640cb53/`, value: '', showIf: (s) => s('CAPTCHA_PROVIDER') === 'Cap' },
-            { key: 'CAP_SECRET_KEY', desc: t('ADMIN_CONFIG_ITEM_CAP_SECRET_KEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}your_cap_secret_key`, value: '', secret: true, showIf: (s) => s('CAPTCHA_PROVIDER') === 'Cap' }
+            { key: 'CAP_API_ENDPOINT', desc: t('ADMIN_CONFIG_ITEM_CAP_API_ENDPOINT'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}https://cap.example.com/d9256640cb53/（留空=内嵌，无需外部服务）`, value: '', showIf: (s) => s('CAPTCHA_PROVIDER') === 'Cap' },
+            { key: 'CAP_SECRET_KEY', desc: t('ADMIN_CONFIG_ITEM_CAP_SECRET_KEY'), ph: `${t('ADMIN_CONFIG_EXAMPLE')}仅外部 Cap 需要；内嵌模式可留空`, value: '', secret: true, showIf: (s) => s('CAPTCHA_PROVIDER') === 'Cap' }
           ]
         },
         {

--- a/src/client/view/components/TkSubmit.vue
+++ b/src/client/view/components/TkSubmit.vue
@@ -113,7 +113,7 @@ export default {
       if (typeof this.config.CAPTCHA_PROVIDER !== 'undefined') return this.config.CAPTCHA_PROVIDER
       if (this.config.TURNSTILE_SITE_KEY) return 'Turnstile'
       if (this.config.GEETEST_CAPTCHA_ID) return 'Geetest'
-      if (this.config.CAP_API_ENDPOINT) return 'Cap'
+      if (this.config.CAP_API_ENDPOINT || this.config.CAP_BUILTIN) return 'Cap'
       return ''
     },
     showImage () {
@@ -242,8 +242,59 @@ export default {
       })
     },
     initCap () {
-      if (this.captchaProvider !== 'Cap' || !this.config.CAP_API_ENDPOINT) return
-      if (window.Cap) {
+      if (this.captchaProvider !== 'Cap') return
+      if (!this.config.CAP_API_ENDPOINT && !this.config.CAP_BUILTIN) return
+      // 内嵌 Cap：widget 的 challenge/redeem 经 Twikoo 事件转发
+      if (this.config.CAP_BUILTIN) {
+        window.CAP_CUSTOM_FETCH = async (url, options = {}) => {
+          const path = String(url)
+          const body = options.body ? JSON.parse(options.body) : {}
+          try {
+            if (path.includes('challenge')) {
+              const res = await call(this.$tcb, 'CAP_CHALLENGE')
+              const result = res.result || res
+              if (result.code && result.code !== 0) {
+                return { ok: false, json: async () => ({ error: result.message || 'challenge_failed' }) }
+              }
+              return {
+                ok: true,
+                json: async () => ({
+                  challenge: result.challenge,
+                  token: result.token,
+                  expires: result.expires
+                })
+              }
+            }
+            if (path.includes('redeem')) {
+              const res = await call(this.$tcb, 'CAP_REDEEM', body)
+              const result = res.result || res
+              if (result.code && result.code !== 0 && result.success !== true) {
+                return {
+                  ok: true,
+                  json: async () => ({
+                    success: false,
+                    error: result.message || result.error || 'redeem_failed'
+                  })
+                }
+              }
+              return {
+                ok: true,
+                json: async () => ({
+                  success: result.success,
+                  token: result.token,
+                  expires: result.expires,
+                  message: result.message,
+                  error: result.error || result.message
+                })
+              }
+            }
+            return { ok: false, json: async () => ({ error: 'unknown_cap_path' }) }
+          } catch (e) {
+            return { ok: false, json: async () => ({ error: e.message || 'cap_fetch_failed' }) }
+          }
+        }
+      }
+      if (window.Cap || customElements.get('cap-widget')) {
         this.capLoad = Promise.resolve()
         return
       }
@@ -260,7 +311,11 @@ export default {
         this.capLoad.then(() => {
           const capWidget = document.createElement('cap-widget')
           capWidget.setAttribute('id', 'cap-widget')
-          capWidget.setAttribute('data-cap-api-endpoint', this.config.CAP_API_ENDPOINT)
+          // 内嵌：endpoint 任意非空，实际请求走 CAP_CUSTOM_FETCH
+          const endpoint = this.config.CAP_BUILTIN
+            ? '/'
+            : this.config.CAP_API_ENDPOINT
+          capWidget.setAttribute('data-cap-api-endpoint', endpoint)
           this.$refs['cap-container'].appendChild(capWidget)
           const cleanup = () => {
             if (capWidget && capWidget.parentNode) {
@@ -278,7 +333,7 @@ export default {
             cleanup()
             reject(e)
           })
-        })
+        }).catch(reject)
       })
     },
     onMetaUpdate (updates) {
@@ -337,7 +392,7 @@ export default {
           comment.geeTestPassToken = geeTestResult.geeTestPassToken
           comment.geeTestGenTime = geeTestResult.geeTestGenTime
         }
-        if (this.captchaProvider === 'Cap' && this.config.CAP_API_ENDPOINT) {
+        if (this.captchaProvider === 'Cap' && (this.config.CAP_API_ENDPOINT || this.config.CAP_BUILTIN)) {
           comment.capToken = await this.getCapToken()
         }
         const sendResult = await call(this.$tcb, 'COMMENT_SUBMIT', comment)

--- a/src/server/eo-makers/cloud-functions/index.js
+++ b/src/server/eo-makers/cloud-functions/index.js
@@ -12,6 +12,7 @@ import xss from 'xss'
 import bowser from 'bowser'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { createRequire } from 'node:module'
 import {
   getMd5,
   getSha256,
@@ -55,6 +56,15 @@ import { sendNotice, emailTest } from 'twikoo-func/utils/notify'
 import { uploadImage } from 'twikoo-func/utils/image'
 import logger from 'twikoo-func/utils/logger'
 import constants from 'twikoo-func/utils/constants'
+
+const require = createRequire(import.meta.url)
+const {
+  createCap,
+  kvStorage,
+  createChallenge,
+  redeemChallenge,
+  isBuiltinCap
+} = require('twikoo-func/utils/cap')
 
 const { RES_CODE, MAX_REQUEST_TIMES } = constants
 const VERSION = '1.7.14'
@@ -633,8 +643,26 @@ function createBlobDatabase () {
       }
       await store.setJSON(key, counter)
       return 1
+    },
+    // Cap.js KV hooks
+    async capGet (key) {
+      return await store.get(key, { type: 'json' })
+    },
+    async capSet (key, value) {
+      await store.setJSON(key, value)
+    },
+    async capDel (key) {
+      try { await store.delete(key) } catch (e) {}
     }
   }
+}
+
+function createEoCap (db) {
+  return createCap(kvStorage({
+    get: (k) => db.capGet(k),
+    set: (k, v) => db.capSet(k, v),
+    del: (k) => db.capDel(k)
+  }))
 }
 
 // ==================== 配置管理 ====================
@@ -1139,6 +1167,16 @@ async function checkCaptcha (event, ip) {
       geeTestPassToken: event.geeTestPassToken,
       geeTestGenTime: event.geeTestGenTime
     })
+  } else if (provider === 'Cap' && isBuiltinCap(config)) {
+    if (!event.capToken) {
+      throw new Error('验证码 token 缺失，请刷新页面重试')
+    }
+    // db is not in scope here — re-create blob db for validation
+    const db = createBlobDatabase()
+    await checkCapCaptcha({
+      capToken: event.capToken,
+      cap: createEoCap(db)
+    })
   } else if (provider === 'Cap' && config.CAP_API_ENDPOINT && config.CAP_SECRET_KEY) {
     if (!event.capToken) {
       throw new Error('验证码 token 缺失，请刷新页面重试')
@@ -1149,7 +1187,7 @@ async function checkCaptcha (event, ip) {
       capApiEndpoint: config.CAP_API_ENDPOINT
     })
   } else if (provider === 'Cap') {
-    throw new Error('Cap 验证码配置不完整，请联系管理员')
+    throw new Error('Cap 验证码配置不完整：内嵌模式无需额外配置，外部模式需填写 CAP_API_ENDPOINT 与 CAP_SECRET_KEY')
   } else if (provider) {
     throw new Error(`不支持的验证码类型: ${provider}`)
   }
@@ -1464,6 +1502,22 @@ async function handlePost (req, res) {
         break
       case 'GET_QQ_NICK':
         result = await qqNickGet(event)
+        break
+      case 'CAP_CHALLENGE':
+        if (!isBuiltinCap(config)) {
+          result = { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+        } else {
+          const data = await createChallenge(createEoCap(db))
+          result = { code: RES_CODE.SUCCESS, ...data }
+        }
+        break
+      case 'CAP_REDEEM':
+        if (!isBuiltinCap(config)) {
+          result = { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+        } else {
+          const data = await redeemChallenge(createEoCap(db), event)
+          result = { code: RES_CODE.SUCCESS, ...data }
+        }
         break
       default:
         if (event.event) {

--- a/src/server/function/twikoo/index.js
+++ b/src/server/function/twikoo/index.js
@@ -39,6 +39,13 @@ const {
   isValidEmail
 } = require('./utils')
 const {
+  createCap,
+  tcbStorage,
+  createChallenge,
+  redeemChallenge,
+  isBuiltinCap
+} = require('./utils/cap')
+const {
   jsonParse,
   commentImportValine,
   commentImportDisqus,
@@ -150,6 +157,12 @@ exports.main = async (event, context) => {
         break
       case 'COMMENT_DELETE_FOR_USER':
         res = await commentDeleteForUser(event)
+        break
+      case 'CAP_CHALLENGE': // embedded Cap.js
+        res = await capChallenge()
+        break
+      case 'CAP_REDEEM':
+        res = await capRedeem(event)
         break
       default:
         if (event.event) {
@@ -760,6 +773,14 @@ async function checkCaptcha (comment) {
       geeTestPassToken: comment.geeTestPassToken,
       geeTestGenTime: comment.geeTestGenTime
     })
+  } else if (provider === 'Cap' && isBuiltinCap(config)) {
+    if (!comment.capToken) {
+      throw new Error('验证码 token 缺失，请刷新页面重试')
+    }
+    await checkCapCaptcha({
+      capToken: comment.capToken,
+      cap: createCap(tcbStorage(db))
+    })
   } else if (provider === 'Cap' && config.CAP_API_ENDPOINT && config.CAP_SECRET_KEY) {
     if (!comment.capToken) {
       throw new Error('验证码 token 缺失，请刷新页面重试')
@@ -770,7 +791,7 @@ async function checkCaptcha (comment) {
       capApiEndpoint: config.CAP_API_ENDPOINT
     })
   } else if (provider === 'Cap') {
-    throw new Error('Cap 验证码配置不完整，请联系管理员')
+    throw new Error('Cap 验证码配置不完整：内嵌模式无需额外配置，外部模式需填写 CAP_API_ENDPOINT 与 CAP_SECRET_KEY')
   } else if (provider) {
     throw new Error(`不支持的验证码类型: ${provider}`)
   }
@@ -1027,9 +1048,27 @@ function isRecursion (context) {
   return envObj.TCB_SOURCE.substr(-3, 3) === 'scf'
 }
 
+async function capChallenge () {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const cap = createCap(tcbStorage(db))
+  const data = await createChallenge(cap)
+  return { code: RES_CODE.SUCCESS, ...data }
+}
+
+async function capRedeem (event) {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const cap = createCap(tcbStorage(db))
+  const data = await redeemChallenge(cap, event)
+  return { code: RES_CODE.SUCCESS, ...data }
+}
+
 // 建立数据库 collections
 async function createCollections () {
-  const collections = ['comment', 'config', 'counter']
+  const collections = ['comment', 'config', 'counter', 'cap_challenges', 'cap_tokens']
   const res = {}
   for (const collection of collections) {
     try {

--- a/src/server/function/twikoo/package.json
+++ b/src/server/function/twikoo/package.json
@@ -11,6 +11,7 @@
   },
   "homepage": "https://twikoo.js.org",
   "dependencies": {
+    "@cap.js/server": "^4.0.5",
     "@cloudbase/manager-node": "^3.9.0",
     "@cloudbase/node-sdk": "^2.5.0",
     "@imaegoo/node-ip2region": "^2.1.1",

--- a/src/server/function/twikoo/utils/cap.js
+++ b/src/server/function/twikoo/utils/cap.js
@@ -1,0 +1,307 @@
+/**
+ * Embedded Cap.js (https://capjs.js.org) — no external Cap Standalone required.
+ * Storage adapters follow the same hooks as @cap.js/server / ink-battles.
+ */
+
+const Cap = require('@cap.js/server')
+const logger = require('./logger')
+
+const CHALLENGE_OPTS = {
+  challengeCount: 50,
+  challengeSize: 32,
+  challengeDifficulty: 4,
+  expiresMs: 600000 // 10 min
+}
+
+function memoryStorage () {
+  const challenges = new Map()
+  const tokens = new Map()
+  return {
+    challenges: {
+      store: async (token, data) => { challenges.set(token, data) },
+      read: async (token) => challenges.get(token) || null,
+      delete: async (token) => { challenges.delete(token) },
+      deleteExpired: async () => {
+        const now = Date.now()
+        for (const [k, v] of challenges) {
+          if (!v || v.expires < now) challenges.delete(k)
+        }
+      }
+    },
+    tokens: {
+      store: async (key, expires) => { tokens.set(key, expires) },
+      get: async (key) => {
+        const exp = tokens.get(key)
+        if (!exp) return null
+        if (exp < Date.now()) {
+          tokens.delete(key)
+          return null
+        }
+        return exp
+      },
+      delete: async (key) => { tokens.delete(key) },
+      deleteExpired: async () => {
+        const now = Date.now()
+        for (const [k, v] of tokens) {
+          if (v < now) tokens.delete(k)
+        }
+      }
+    }
+  }
+}
+
+/** MongoDB (native driver) — Vercel / self-hosted mongo */
+function mongoStorage (db) {
+  const challenges = () => db.collection('cap_challenges')
+  const tokens = () => db.collection('cap_tokens')
+  let indexed = false
+  const ensureIndex = () => {
+    if (indexed) return
+    indexed = true
+    challenges().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }).catch(() => {})
+    tokens().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }).catch(() => {})
+  }
+  return {
+    challenges: {
+      store: async (token, data) => {
+        ensureIndex()
+        await challenges().updateOne(
+          { token },
+          { $set: { token, challenge: data.challenge, expiresAt: new Date(data.expires) } },
+          { upsert: true }
+        )
+      },
+      read: async (token) => {
+        const doc = await challenges().findOne({ token, expiresAt: { $gt: new Date() } })
+        return doc ? { challenge: doc.challenge, expires: doc.expiresAt.getTime() } : null
+      },
+      delete: async (token) => { await challenges().deleteOne({ token }) },
+      deleteExpired: async () => { await challenges().deleteMany({ expiresAt: { $lte: new Date() } }) }
+    },
+    tokens: {
+      store: async (key, expires) => {
+        ensureIndex()
+        await tokens().updateOne(
+          { key },
+          { $set: { key, expiresAt: new Date(expires) } },
+          { upsert: true }
+        )
+      },
+      get: async (key) => {
+        const doc = await tokens().findOne({ key, expiresAt: { $gt: new Date() } })
+        return doc ? doc.expiresAt.getTime() : null
+      },
+      delete: async (key) => { await tokens().deleteOne({ key }) },
+      deleteExpired: async () => { await tokens().deleteMany({ expiresAt: { $lte: new Date() } }) }
+    }
+  }
+}
+
+/** LokiJS — self-hosted default */
+function lokiStorage (db) {
+  const getCol = (name) => {
+    let col = db.getCollection(name)
+    if (!col) col = db.addCollection(name, { unique: ['key'] })
+    return col
+  }
+  // challenges use token field; tokens use key field
+  const getChallengeCol = () => {
+    let col = db.getCollection('cap_challenges')
+    if (!col) col = db.addCollection('cap_challenges', { unique: ['token'] })
+    return col
+  }
+  const getTokenCol = () => getCol('cap_tokens')
+  return {
+    challenges: {
+      store: async (token, data) => {
+        const col = getChallengeCol()
+        const existing = col.findOne({ token })
+        const row = { token, challenge: data.challenge, expires: data.expires }
+        if (existing) col.update({ ...existing, ...row })
+        else col.insert(row)
+      },
+      read: async (token) => {
+        const doc = getChallengeCol().findOne({ token })
+        if (!doc || doc.expires < Date.now()) return null
+        return { challenge: doc.challenge, expires: doc.expires }
+      },
+      delete: async (token) => { getChallengeCol().findAndRemove({ token }) },
+      deleteExpired: async () => {
+        getChallengeCol().findAndRemove({ expires: { $lte: Date.now() } })
+      }
+    },
+    tokens: {
+      store: async (key, expires) => {
+        const col = getTokenCol()
+        const existing = col.findOne({ key })
+        const row = { key, expires }
+        if (existing) col.update({ ...existing, ...row })
+        else col.insert(row)
+      },
+      get: async (key) => {
+        const doc = getTokenCol().findOne({ key })
+        if (!doc || doc.expires < Date.now()) return null
+        return doc.expires
+      },
+      delete: async (key) => { getTokenCol().findAndRemove({ key }) },
+      deleteExpired: async () => {
+        getTokenCol().findAndRemove({ expires: { $lte: Date.now() } })
+      }
+    }
+  }
+}
+
+/** CloudBase / TCB database */
+function tcbStorage (db) {
+  const _ = db.command
+  return {
+    challenges: {
+      store: async (token, data) => {
+        const col = db.collection('cap_challenges')
+        try {
+          await col.doc(token).set({
+            token,
+            challenge: data.challenge,
+            expires: data.expires
+          })
+        } catch (e) {
+          // doc may exist
+          await col.doc(token).update({
+            challenge: data.challenge,
+            expires: data.expires
+          })
+        }
+      },
+      read: async (token) => {
+        try {
+          const res = await db.collection('cap_challenges').doc(token).get()
+          const doc = res.data && res.data[0]
+          if (!doc || doc.expires < Date.now()) return null
+          return { challenge: doc.challenge, expires: doc.expires }
+        } catch (e) {
+          return null
+        }
+      },
+      delete: async (token) => {
+        try { await db.collection('cap_challenges').doc(token).remove() } catch (e) {}
+      },
+      deleteExpired: async () => {
+        try {
+          await db.collection('cap_challenges').where({ expires: _.lte(Date.now()) }).remove()
+        } catch (e) {}
+      }
+    },
+    tokens: {
+      store: async (key, expires) => {
+        // CloudBase doc id cannot contain ':'
+        const id = key.replace(/:/g, '_')
+        try {
+          await db.collection('cap_tokens').doc(id).set({ key, expires })
+        } catch (e) {
+          await db.collection('cap_tokens').doc(id).update({ key, expires })
+        }
+      },
+      get: async (key) => {
+        try {
+          const id = key.replace(/:/g, '_')
+          const res = await db.collection('cap_tokens').doc(id).get()
+          const doc = res.data && res.data[0]
+          if (!doc || doc.expires < Date.now()) return null
+          return doc.expires
+        } catch (e) {
+          return null
+        }
+      },
+      delete: async (key) => {
+        try {
+          const id = key.replace(/:/g, '_')
+          await db.collection('cap_tokens').doc(id).remove()
+        } catch (e) {}
+      },
+      deleteExpired: async () => {
+        try {
+          await db.collection('cap_tokens').where({ expires: _.lte(Date.now()) }).remove()
+        } catch (e) {}
+      }
+    }
+  }
+}
+
+/**
+ * EdgeOne Blob-style store: expects { get(key), set(key, value), del(key) }
+ * value is JSON-serializable.
+ */
+function kvStorage (kv) {
+  return {
+    challenges: {
+      store: async (token, data) => { await kv.set(`cap:c:${token}`, data) },
+      read: async (token) => {
+        const data = await kv.get(`cap:c:${token}`)
+        if (!data || data.expires < Date.now()) return null
+        return data
+      },
+      delete: async (token) => { await kv.del(`cap:c:${token}`) },
+      deleteExpired: async () => {}
+    },
+    tokens: {
+      store: async (key, expires) => { await kv.set(`cap:t:${key}`, { expires }) },
+      get: async (key) => {
+        const data = await kv.get(`cap:t:${key}`)
+        if (!data || data.expires < Date.now()) return null
+        return data.expires
+      },
+      delete: async (key) => { await kv.del(`cap:t:${key}`) },
+      deleteExpired: async () => {}
+    }
+  }
+}
+
+function createCap (storage) {
+  return new Cap({
+    noFSState: true,
+    storage: storage || memoryStorage()
+  })
+}
+
+async function createChallenge (cap) {
+  return cap.createChallenge(CHALLENGE_OPTS)
+}
+
+async function redeemChallenge (cap, body) {
+  const token = body && body.token
+  const solutions = body && body.solutions
+  if (!token || !solutions || !Array.isArray(solutions)) {
+    return { success: false, error: 'Missing token or solutions' }
+  }
+  return cap.redeemChallenge({ token, solutions })
+}
+
+async function validateToken (cap, token) {
+  if (!token) return false
+  try {
+    const { success } = await cap.validateToken(token)
+    return !!success
+  } catch (e) {
+    logger.error('Cap validateToken failed:', e)
+    return false
+  }
+}
+
+/** CAPTCHA_PROVIDER=Cap and no CAP_API_ENDPOINT → use embedded Cap */
+function isBuiltinCap (config) {
+  return config && config.CAPTCHA_PROVIDER === 'Cap' && !config.CAP_API_ENDPOINT
+}
+
+module.exports = {
+  createCap,
+  memoryStorage,
+  mongoStorage,
+  lokiStorage,
+  tcbStorage,
+  kvStorage,
+  createChallenge,
+  redeemChallenge,
+  validateToken,
+  isBuiltinCap,
+  CHALLENGE_OPTS
+}

--- a/src/server/function/twikoo/utils/cap.js
+++ b/src/server/function/twikoo/utils/cap.js
@@ -117,8 +117,10 @@ function lokiStorage (db) {
         const col = getChallengeCol()
         const existing = col.findOne({ token })
         const row = { token, challenge: data.challenge, expires: data.expires }
-        if (existing) col.update({ ...existing, ...row })
-        else col.insert(row)
+        if (existing) {
+          Object.assign(existing, row)
+          col.update(existing)
+        } else col.insert(row)
       },
       read: async (token) => {
         const doc = getChallengeCol().findOne({ token })
@@ -135,8 +137,10 @@ function lokiStorage (db) {
         const col = getTokenCol()
         const existing = col.findOne({ key })
         const row = { key, expires }
-        if (existing) col.update({ ...existing, ...row })
-        else col.insert(row)
+        if (existing) {
+          Object.assign(existing, row)
+          col.update(existing)
+        } else col.insert(row)
       },
       get: async (key) => {
         const doc = getTokenCol().findOne({ key })

--- a/src/server/function/twikoo/utils/index.js
+++ b/src/server/function/twikoo/utils/index.js
@@ -366,11 +366,17 @@ const fn = {
       throw new Error('极验验证码检测失败: ' + e.message)
     }
   },
-  async checkCapCaptcha ({ capToken, capSecretKey, capApiEndpoint }) {
+  async checkCapCaptcha ({ capToken, capSecretKey, capApiEndpoint, cap }) {
     try {
-      // 移除末尾的斜杠，避免双斜杠
+      // 内嵌 Cap：直接 validateToken，无需外部 Standalone
+      if (cap) {
+        const { validateToken } = require('./cap')
+        const ok = await validateToken(cap, capToken)
+        if (!ok) throw new Error('验证码错误')
+        return
+      }
+      // 外部 Cap Standalone：HTTP siteverify
       const endpoint = capApiEndpoint.replace(/\/$/, '')
-      // Cap 的 siteverify 端点
       const url = `${endpoint}/siteverify`
       logger.log('Cap验证码验证URL:', url)
       logger.log('Cap验证码验证参数:', { secret: capSecretKey ? '***' : undefined, response: capToken.substring(0, 20) + '...' })
@@ -426,9 +432,13 @@ const fn = {
       baseConfig.GEETEST_CAPTCHA_ID = config.GEETEST_CAPTCHA_ID
     }
 
-    // 仅在明确指定使用 Cap 时下发 Cap 的 api endpoint
+    // Cap：有外部 endpoint 则下发；否则标记 builtin，前端走 twikoo 事件代理
     if (config.CAPTCHA_PROVIDER === 'Cap') {
-      baseConfig.CAP_API_ENDPOINT = config.CAP_API_ENDPOINT
+      if (config.CAP_API_ENDPOINT) {
+        baseConfig.CAP_API_ENDPOINT = config.CAP_API_ENDPOINT
+      } else {
+        baseConfig.CAP_BUILTIN = true
+      }
     }
 
     return {

--- a/src/server/self-hosted/index.js
+++ b/src/server/self-hosted/index.js
@@ -44,6 +44,13 @@ const {
   isValidEmail
 } = require('twikoo-func/utils')
 const {
+  createCap,
+  lokiStorage,
+  createChallenge,
+  redeemChallenge,
+  isBuiltinCap
+} = require('twikoo-func/utils/cap')
+const {
   jsonParse,
   commentImportValine,
   commentImportDisqus,
@@ -156,6 +163,12 @@ module.exports = async (request, response) => {
         break
       case 'COMMENT_EXPORT_FOR_ADMIN': // >= 1.6.13
         res = await commentExportForAdmin(event)
+        break
+      case 'CAP_CHALLENGE':
+        res = await capChallenge()
+        break
+      case 'CAP_REDEEM':
+        res = await capRedeem(event)
         break
       default:
         if (event.event) {
@@ -801,6 +814,14 @@ async function checkCaptcha (comment, request) {
       geeTestPassToken: comment.geeTestPassToken,
       geeTestGenTime: comment.geeTestGenTime
     })
+  } else if (provider === 'Cap' && isBuiltinCap(config)) {
+    if (!comment.capToken) {
+      throw new Error('验证码 token 缺失，请刷新页面重试')
+    }
+    await checkCapCaptcha({
+      capToken: comment.capToken,
+      cap: createCap(lokiStorage(db))
+    })
   } else if (provider === 'Cap' && config.CAP_API_ENDPOINT && config.CAP_SECRET_KEY) {
     if (!comment.capToken) {
       throw new Error('验证码 token 缺失，请刷新页面重试')
@@ -811,7 +832,7 @@ async function checkCaptcha (comment, request) {
       capApiEndpoint: config.CAP_API_ENDPOINT
     })
   } else if (provider === 'Cap') {
-    throw new Error('Cap 验证码配置不完整，请联系管理员')
+    throw new Error('Cap 验证码配置不完整：内嵌模式无需额外配置，外部模式需填写 CAP_API_ENDPOINT 与 CAP_SECRET_KEY')
   } else if (provider) {
     throw new Error(`不支持的验证码类型: ${provider}`)
   }
@@ -1047,7 +1068,7 @@ function isAdmin (accessToken) {
 
 // 建立数据库 collections
 async function createCollections () {
-  const collections = ['comment', 'config', 'counter']
+  const collections = ['comment', 'config', 'counter', 'cap_challenges', 'cap_tokens']
   const res = {}
   for (const collection of collections) {
     if (db.getCollection(collection) === null) {
@@ -1055,6 +1076,22 @@ async function createCollections () {
     }
   }
   return res
+}
+
+async function capChallenge () {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await createChallenge(createCap(lokiStorage(db)))
+  return { code: RES_CODE.SUCCESS, ...data }
+}
+
+async function capRedeem (event) {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await redeemChallenge(createCap(lokiStorage(db)), event)
+  return { code: RES_CODE.SUCCESS, ...data }
 }
 
 function getIp (request) {

--- a/src/server/self-hosted/mongo.js
+++ b/src/server/self-hosted/mongo.js
@@ -40,6 +40,13 @@ const {
   checkCommentOwnership
 } = require('twikoo-func/utils')
 const {
+  createCap,
+  mongoStorage,
+  createChallenge,
+  redeemChallenge,
+  isBuiltinCap
+} = require('twikoo-func/utils/cap')
+const {
   jsonParse,
   commentImportValine,
   commentImportDisqus,
@@ -149,6 +156,12 @@ module.exports = async (request, response) => {
         break
       case 'COMMENT_EXPORT_FOR_ADMIN': // >= 1.6.13
         res = await commentExportForAdmin(event)
+        break
+      case 'CAP_CHALLENGE':
+        res = await capChallenge()
+        break
+      case 'CAP_REDEEM':
+        res = await capRedeem(event)
         break
       default:
         if (event.event) {
@@ -777,6 +790,14 @@ async function checkCaptcha (comment, request) {
       geeTestPassToken: comment.geeTestPassToken,
       geeTestGenTime: comment.geeTestGenTime
     })
+  } else if (provider === 'Cap' && isBuiltinCap(config)) {
+    if (!comment.capToken) {
+      throw new Error('验证码 token 缺失，请刷新页面重试')
+    }
+    await checkCapCaptcha({
+      capToken: comment.capToken,
+      cap: createCap(mongoStorage(db))
+    })
   } else if (provider === 'Cap' && config.CAP_API_ENDPOINT && config.CAP_SECRET_KEY) {
     if (!comment.capToken) {
       throw new Error('验证码 token 缺失，请刷新页面重试')
@@ -787,7 +808,7 @@ async function checkCaptcha (comment, request) {
       capApiEndpoint: config.CAP_API_ENDPOINT
     })
   } else if (provider === 'Cap') {
-    throw new Error('Cap 验证码配置不完整，请联系管理员')
+    throw new Error('Cap 验证码配置不完整：内嵌模式无需额外配置，外部模式需填写 CAP_API_ENDPOINT 与 CAP_SECRET_KEY')
   } else if (provider) {
     throw new Error(`不支持的验证码类型: ${provider}`)
   }
@@ -1016,7 +1037,7 @@ function isAdmin (accessToken) {
 
 // 建立数据库 collections
 async function createCollections () {
-  const collections = ['comment', 'config', 'counter']
+  const collections = ['comment', 'config', 'counter', 'cap_challenges', 'cap_tokens']
   const res = {}
   for (const collection of collections) {
     try {
@@ -1026,6 +1047,22 @@ async function createCollections () {
     }
   }
   return res
+}
+
+async function capChallenge () {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await createChallenge(createCap(mongoStorage(db)))
+  return { code: RES_CODE.SUCCESS, ...data }
+}
+
+async function capRedeem (event) {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await redeemChallenge(createCap(mongoStorage(db)), event)
+  return { code: RES_CODE.SUCCESS, ...data }
 }
 
 function getIp (request) {

--- a/src/server/vercel/api/index.js
+++ b/src/server/vercel/api/index.js
@@ -43,6 +43,13 @@ const {
   isValidEmail
 } = require('twikoo-func/utils')
 const {
+  createCap,
+  mongoStorage,
+  createChallenge,
+  redeemChallenge,
+  isBuiltinCap
+} = require('twikoo-func/utils/cap')
+const {
   jsonParse,
   commentImportValine,
   commentImportDisqus,
@@ -156,6 +163,12 @@ module.exports = async (request, response) => {
         break
       case 'COMMENT_EXPORT_FOR_ADMIN': // >= 1.6.13
         res = await commentExportForAdmin(event)
+        break
+      case 'CAP_CHALLENGE':
+        res = await capChallenge()
+        break
+      case 'CAP_REDEEM':
+        res = await capRedeem(event)
         break
       default:
         if (event.event) {
@@ -796,6 +809,14 @@ async function checkCaptcha (comment, request) {
       geeTestPassToken: comment.geeTestPassToken,
       geeTestGenTime: comment.geeTestGenTime
     })
+  } else if (provider === 'Cap' && isBuiltinCap(config)) {
+    if (!comment.capToken) {
+      throw new Error('验证码 token 缺失，请刷新页面重试')
+    }
+    await checkCapCaptcha({
+      capToken: comment.capToken,
+      cap: createCap(mongoStorage(db))
+    })
   } else if (provider === 'Cap' && config.CAP_API_ENDPOINT && config.CAP_SECRET_KEY) {
     if (!comment.capToken) {
       throw new Error('验证码 token 缺失，请刷新页面重试')
@@ -806,7 +827,7 @@ async function checkCaptcha (comment, request) {
       capApiEndpoint: config.CAP_API_ENDPOINT
     })
   } else if (provider === 'Cap') {
-    throw new Error('Cap 验证码配置不完整，请联系管理员')
+    throw new Error('Cap 验证码配置不完整：内嵌模式无需额外配置，外部模式需填写 CAP_API_ENDPOINT 与 CAP_SECRET_KEY')
   } else if (provider) {
     throw new Error(`不支持的验证码类型: ${provider}`)
   }
@@ -1061,7 +1082,7 @@ function isRecursion (request) {
 
 // 建立数据库 collections
 async function createCollections () {
-  const collections = ['comment', 'config', 'counter']
+  const collections = ['comment', 'config', 'counter', 'cap_challenges', 'cap_tokens']
   const res = {}
   for (const collection of collections) {
     try {
@@ -1071,6 +1092,22 @@ async function createCollections () {
     }
   }
   return res
+}
+
+async function capChallenge () {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await createChallenge(createCap(mongoStorage(db)))
+  return { code: RES_CODE.SUCCESS, ...data }
+}
+
+async function capRedeem (event) {
+  if (!isBuiltinCap(config)) {
+    return { code: RES_CODE.FAIL, message: '内嵌 Cap 未启用' }
+  }
+  const data = await redeemChallenge(createCap(mongoStorage(db)), event)
+  return { code: RES_CODE.SUCCESS, ...data }
 }
 
 function getIp (request) {


### PR DESCRIPTION
## Summary by Sourcery

添加内置的 Cap.js CAPTCHA 支持，在无需部署外部 Cap 服务器的情况下即可工作，并将其集成到所有运行时和客户端中。

新功能：
- 支持嵌入式 Cap.js 模式，使用 Twikoo 后端进行挑战与令牌校验，而不是使用外部 Cap API 端点。
- 在所有服务器运行时中暴露 `CAP_CHALLENGE` 和 `CAP_REDEEM` 事件/处理器，以便通过 Twikoo 驱动嵌入式 Cap.js 小部件。
- 当在没有外部端点的情况下选择 Cap 时，自动在客户端配置中将其标记为内置（builtin），以便前端可以即开即用地进行初始化。

增强：
- 改进与 Cap 相关的管理端和 i18n 文案，明确说明在何种情况下需要外部端点和密钥，何种情况下为可选。
- 扩展各运行时中的数据库初始化逻辑，创建 `cap_challenges` 和 `cap_tokens` 集合/表，用于存储 Cap.js 状态。
- 优化 Cap 配置校验与错误信息（适用于内置模式和外部模式），并提升客户端加载 Cap 小部件的健壮性。

构建：
- 为 Twikoo 云函数运行时添加 `@cap.js/server` 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add built-in Cap.js CAPTCHA support that works without deploying an external Cap server and integrate it across all runtimes and the client.

New Features:
- Support an embedded Cap.js mode that uses Twikoo backends for challenge and token validation instead of an external Cap API endpoint.
- Expose CAP_CHALLENGE and CAP_REDEEM events/handlers in all server runtimes to drive the embedded Cap.js widget via Twikoo.
- Automatically mark Cap as builtin in client config when selected without an external endpoint so the front end can initialize it out of the box.

Enhancements:
- Improve Cap-related admin and i18n copy to clarify when external endpoints and secret keys are required versus optional.
- Extend database initialization across runtimes to create cap_challenges and cap_tokens collections/tables for storing Cap.js state.
- Refine Cap configuration validation and error messages for both builtin and external modes, and make Cap widget loading more robust on the client.

Build:
- Add @cap.js/server dependency for the Twikoo cloud function runtime.

</details>