### PR TITLE
fix: 修复 EdgeOne 构建 xsai 依赖失败

### DIFF
--- a/src/server/function/twikoo/package.json
+++ b/src/server/function/twikoo/package.json
@@ -11,6 +11,9 @@
   },
   "homepage": "https://twikoo.js.org",
   "dependencies": {
+    "@xsai/generate-text": "0.2.2",
+    "@xsai/shared": "0.2.2",
+    "@xsai/shared-chat": "0.2.2",
     "@cap.js/server": "^4.0.5",
     "@cloudbase/manager-node": "^3.9.0",
     "@cloudbase/node-sdk": "^2.5.0",
@@ -28,7 +31,6 @@
     "nodemailer": "^7.0.11",
     "pushoo": "latest",
     "tencentcloud-sdk-nodejs": "^4.0.65",
-    "xml2js": "^0.6.0",
-    "xsai": "^0.2.2"
+    "xml2js": "^0.6.0"
   }
 }

--- a/src/server/function/twikoo/utils/lib.js
+++ b/src/server/function/twikoo/utils/lib.js
@@ -71,13 +71,5 @@ module.exports = {
   getXml2js () {
     const xml2js = require('xml2js') // XML 解析
     return xml2js
-  },
-  getOpenAIClient (config) {
-    const { createXSClient } = require('xsai') // xsai SDK
-    const openaiClient = createXSClient({
-      apiKey: config.LLM_API_KEY,
-      baseURL: config.LLM_API_ENDPOINT || 'https://api.deepseek.com/v1'
-    })
-    return openaiClient
   }
 }

--- a/src/server/function/twikoo/utils/spam.js
+++ b/src/server/function/twikoo/utils/spam.js
@@ -12,6 +12,7 @@ const CryptoJS = getCryptoJS()
 const logger = require('./logger')
 
 let tencentcloud
+let generateTextPromise
 
 function getTencentCloud () {
   if (!tencentcloud) {
@@ -22,6 +23,18 @@ function getTencentCloud () {
     }
   }
   return tencentcloud
+}
+
+function getGenerateText () {
+  if (!generateTextPromise) {
+    generateTextPromise = import('@xsai/generate-text')
+      .then(({ generateText }) => generateText)
+      .catch((error) => {
+        generateTextPromise = null
+        throw error
+      })
+  }
+  return generateTextPromise
 }
 
 // 提取json结构的函数
@@ -121,7 +134,7 @@ async function checkByLLM (comment, config) {
         messages = buildMessages(comment, lastError)
       }
 
-      const { generateText } = await import('@xsai/generate-text')
+      const generateText = await getGenerateText()
       const chatCompletion = await generateText({
         apiKey: config.LLM_API_KEY,
         baseURL: config.LLM_API_ENDPOINT || 'https://api.deepseek.com/v1',

--- a/src/server/function/twikoo/utils/spam.js
+++ b/src/server/function/twikoo/utils/spam.js
@@ -121,8 +121,10 @@ async function checkByLLM (comment, config) {
         messages = buildMessages(comment, lastError)
       }
 
-      const { generateText } = require('xsai')
+      const { generateText } = await import('@xsai/generate-text')
       const chatCompletion = await generateText({
+        apiKey: config.LLM_API_KEY,
+        baseURL: config.LLM_API_ENDPOINT || 'https://api.deepseek.com/v1',
         model: config.LLM_MODEL || 'deepseek-chat',
         responseFormat: { type: 'json_object' },
         messages


### PR DESCRIPTION
## 问题

EdgeOne Makers 在打包 Node Functions 时，会扫描 `xsai` 聚合包间接引入的 `xsschema`。`xsschema` 中对 `sury`、`effect` 和 `@valibot/to-json-schema` 的可选动态导入会被构建器解析，导致构建失败。

## 修改

- 将 `xsai` 聚合包替换为实际使用的 `@xsai/generate-text` 按需依赖，避免引入无关的 schema 依赖链
- 固定同代 `@xsai/shared` 和 `@xsai/shared-chat` 版本，避免 `0.2.2` 的空依赖范围解析到不兼容的新版本
- 使用动态 `import()` 加载 ESM 包，并将 `apiKey`、`baseURL` 直接传给 `generateText`
- 移除未被调用且依赖不存在导出的 `getOpenAIClient`

保留了 #1024 引入 xsai 以减小包体积的整体方案，没有改用其他 LLM SDK，也没有增加 EdgeOne 构建补丁。

## 验证

- `pnpm lint`
- `pnpm build`
- Node.js 24 原生 `fetch` 下的 xsai 请求链测试（鉴权、Endpoint、JSON 模式及 HAM/SPAM 返回）
- EdgeOne CLI Node Functions 和 Go Functions 构建成功
- EdgeOne 本地请求返回 HTTP 200
- 最终 bundle 不包含 `xsschema`、`sury`、`effect`、`@valibot/to-json-schema`

## Summary by Sourcery

将 Twikoo 的基于 LLM 的垃圾评论检查切换为使用仅支持 ESM 的 `@xsai/generate-text` 包，并采用显式配置，同时移除之前的 `xsai` 聚合依赖和未使用的辅助函数，以修复 EdgeOne 构建失败问题。

Bug Fixes:
- 通过用 `@xsai/generate-text` 的 ESM 导入替换 `xsai` 的使用，并在垃圾检查中直接传递 `apiKey`/`baseURL`，解决 EdgeOne 构建失败问题。

Enhancements:
- 从 Twikoo 工具集中移除未使用的 `getOpenAIClient` 辅助函数，以简化 LLM 集成。
- 将 `@xsai/generate-text`、`@xsai/shared` 和 `@xsai/shared-chat` 固定在兼容的 `0.2.2` 版本，并移除 `xsai` 聚合依赖，以避免不兼容的与 schema 相关的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch Twikoo’s LLM-based spam check to use the ESM-only @xsai/generate-text package with explicit configuration, and remove the previous xsai aggregate dependency and unused helper to fix EdgeOne build failures.

Bug Fixes:
- Resolve EdgeOne build failures by replacing xsai usage with @xsai/generate-text ESM import and passing apiKey/baseURL directly in the spam check.

Enhancements:
- Remove the unused getOpenAIClient helper from Twikoo utilities to simplify LLM integration.
- Pin @xsai/generate-text, @xsai/shared, and @xsai/shared-chat to compatible 0.2.2 versions and drop the xsai aggregate dependency to avoid incompatible schema-related dependencies.

</details>

Bug 修复：
- 确保基于 LLM 的垃圾信息检查对 `@xsai/generate-text` 使用 ESM 导入，并显式传入 `apiKey` 和 `baseURL`，以避免 EdgeOne 构建问题。

改进：
- 从 Twikoo 工具中移除未使用的 `getOpenAIClient` 辅助函数，以简化 LLM 集成。
- 固定 `@xsai/generate-text`、`@xsai/shared` 和 `@xsai/shared-chat` 到兼容版本，并移除 `xsai` 聚合包，以减少与 schema 相关的依赖链。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Twikoo 的基于 LLM 的垃圾评论检查切换为使用仅支持 ESM 的 `@xsai/generate-text` 包，并采用显式配置，同时移除之前的 `xsai` 聚合依赖和未使用的辅助函数，以修复 EdgeOne 构建失败问题。

Bug Fixes:
- 通过用 `@xsai/generate-text` 的 ESM 导入替换 `xsai` 的使用，并在垃圾检查中直接传递 `apiKey`/`baseURL`，解决 EdgeOne 构建失败问题。

Enhancements:
- 从 Twikoo 工具集中移除未使用的 `getOpenAIClient` 辅助函数，以简化 LLM 集成。
- 将 `@xsai/generate-text`、`@xsai/shared` 和 `@xsai/shared-chat` 固定在兼容的 `0.2.2` 版本，并移除 `xsai` 聚合依赖，以避免不兼容的与 schema 相关的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch Twikoo’s LLM-based spam check to use the ESM-only @xsai/generate-text package with explicit configuration, and remove the previous xsai aggregate dependency and unused helper to fix EdgeOne build failures.

Bug Fixes:
- Resolve EdgeOne build failures by replacing xsai usage with @xsai/generate-text ESM import and passing apiKey/baseURL directly in the spam check.

Enhancements:
- Remove the unused getOpenAIClient helper from Twikoo utilities to simplify LLM integration.
- Pin @xsai/generate-text, @xsai/shared, and @xsai/shared-chat to compatible 0.2.2 versions and drop the xsai aggregate dependency to avoid incompatible schema-related dependencies.

</details>

</details>