### PR TITLE
fix: migrate CloudBase auth calls to SDK 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,4 @@ jobs:
     - run: yarn install
     - run: yarn build
     - run: yarn lint
+    - run: yarn test

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "dev": "webpack serve --mode development",
     "serve": "webpack serve --mode development",
     "build": "cross-env NODE_ENV=production webpack --mode production",
+    "test": "node --test test/*.test.mjs",
     "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
     "login": "tcb login",
     "logout": "tcb logout",
     "deploy": "tcb fn deploy twikoo --force",
-    "lint": "eslint src/**",
+    "lint": "eslint src/** test/**",
     "docs:dev": "cd docs && yarn docs:dev",
     "docs:build": "cd docs && yarn docs:build"
   },

--- a/src/client/utils/tcb-auth.mjs
+++ b/src/client/utils/tcb-auth.mjs
@@ -9,7 +9,7 @@ const isCustomUser = (user) => Boolean(
   user && (
     user.loginType === 'CUSTOM' ||
     (Array.isArray(user.providers) &&
-      user.providers.some((provider) => provider.id === 'custom'))
+      user.providers.some((provider) => provider && provider.id === 'custom'))
   )
 )
 

--- a/src/client/utils/tcb-auth.mjs
+++ b/src/client/utils/tcb-auth.mjs
@@ -1,0 +1,23 @@
+const signInAnonymously = (auth) => auth.signInAnonymously()
+
+const signInWithCustomTicket = (auth, ticket) => {
+  auth.setCustomSignFunc(() => Promise.resolve(ticket))
+  return auth.signInWithCustomTicket()
+}
+
+const isCustomUser = (user) => Boolean(
+  user && (
+    user.loginType === 'CUSTOM' ||
+    (Array.isArray(user.providers) &&
+      user.providers.some((provider) => provider.id === 'custom'))
+  )
+)
+
+const hasCustomLogin = async (auth) => isCustomUser(await auth.getCurrentUser())
+
+export {
+  signInAnonymously,
+  signInWithCustomTicket,
+  isCustomUser,
+  hasCustomLogin
+}

--- a/src/client/utils/tcb.js
+++ b/src/client/utils/tcb.js
@@ -2,6 +2,7 @@ import {
   isNotSet,
   logger
 } from '.'
+import { signInAnonymously } from './tcb-auth.mjs'
 
 const builtInOptions = [
   { key: 'envId', required: true }
@@ -55,9 +56,7 @@ async function initAuth () {
     if (tcb.auth.hasLoginState()) {
       resolve()
     } else {
-      tcb.auth
-        .anonymousAuthProvider()
-        .signIn()
+      signInAnonymously(tcb.auth)
         .then(resolve)
         .catch(reject)
     }

--- a/src/client/view/components/TkAdmin.vue
+++ b/src/client/view/components/TkAdmin.vue
@@ -68,6 +68,7 @@ import TkAdminConfig from './TkAdminConfig.vue'
 import TkAdminImport from './TkAdminImport.vue'
 import TkAdminExport from './TkAdminExport.vue'
 import { logger, call, t } from '../../utils'
+import { hasCustomLogin, signInAnonymously, signInWithCustomTicket } from '../../utils/tcb-auth.mjs'
 import iconClose from '@fortawesome/fontawesome-free/svgs/solid/times.svg'
 
 export default {
@@ -121,9 +122,7 @@ export default {
         this.loginErrorMessage = res.result.message
       } else if (res.result.ticket) {
         try {
-          await this.$tcb.auth
-            .customAuthProvider()
-            .signIn(res.result.ticket)
+          await signInWithCustomTicket(this.$tcb.auth, res.result.ticket)
           logger.log('登录成功')
           this.password = ''
           this.checkAuth()
@@ -143,9 +142,7 @@ export default {
       this.loading = true
       if (this.$tcb) {
         await this.$tcb.auth.signOut()
-        await this.$tcb.auth
-          .anonymousAuthProvider()
-          .signIn()
+        await signInAnonymously(this.$tcb.auth)
       } else {
         localStorage.removeItem('twikoo-access-token')
       }
@@ -190,8 +187,7 @@ export default {
     async checkAuth () {
       // 检查用户身份
       if (this.$tcb) {
-        const currentUser = await this.$tcb.auth.getCurrenUser()
-        this.isLogin = currentUser.loginType === 'CUSTOM'
+        this.isLogin = await hasCustomLogin(this.$tcb.auth)
       } else {
         const result = await call(this.$tcb, 'GET_CONFIG')
         if (result && result.result && result.result.config) {

--- a/src/client/view/components/TkComment.vue
+++ b/src/client/view/components/TkComment.vue
@@ -93,6 +93,7 @@
 
 <script>
 import { timeago, convertLink, call, renderLinks, renderMath, renderCode, t } from '../../utils'
+import { hasCustomLogin } from '../../utils/tcb-auth.mjs'
 import TkAction from './TkAction.vue'
 import TkAvatar from './TkAvatar.vue'
 import TkSubmit from './TkSubmit.vue'
@@ -327,8 +328,7 @@ export default {
     async checkAuth () {
       // 检查用户身份
       if (this.$tcb) {
-        const currentUser = await this.$tcb.auth.getCurrenUser()
-        this.isLogin = currentUser.loginType === 'CUSTOM'
+        this.isLogin = await hasCustomLogin(this.$tcb.auth)
       } else {
         this.isLogin = this.$twikoo.serverConfig && this.$twikoo.serverConfig.IS_ADMIN
       }

--- a/test/tcb-auth.test.mjs
+++ b/test/tcb-auth.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  hasCustomLogin,
+  isCustomUser,
+  signInAnonymously,
+  signInWithCustomTicket
+} from '../src/client/utils/tcb-auth.mjs'
+
+test('signs in anonymously with the CloudBase SDK 4 API', async () => {
+  const expected = { user: { providers: [{ id: 'anonymous' }] } }
+  const auth = {
+    signInAnonymously: async () => expected
+  }
+
+  assert.equal(await signInAnonymously(auth), expected)
+})
+
+test('configures and uses CloudBase SDK 4 custom ticket login', async () => {
+  const expected = { user: { providers: [{ id: 'custom' }] } }
+  let getTicket
+  const auth = {
+    setCustomSignFunc: (callback) => { getTicket = callback },
+    signInWithCustomTicket: async () => expected
+  }
+
+  assert.equal(await signInWithCustomTicket(auth, 'ticket'), expected)
+  assert.equal(await getTicket(), 'ticket')
+})
+
+test('recognizes CloudBase SDK 4 custom providers', async () => {
+  const user = { providers: [{ id: 'anonymous' }, { id: 'custom' }] }
+  const auth = { getCurrentUser: async () => user }
+
+  assert.equal(isCustomUser(user), true)
+  assert.equal(await hasCustomLogin(auth), true)
+})
+
+test('rejects anonymous, missing, and unrelated providers', () => {
+  assert.equal(isCustomUser(null), false)
+  assert.equal(isCustomUser({}), false)
+  assert.equal(isCustomUser({ providers: [{ id: 'anonymous' }] }), false)
+})
+
+test('keeps compatibility with the legacy custom login marker', () => {
+  assert.equal(isCustomUser({ loginType: 'CUSTOM' }), true)
+})

--- a/test/tcb-auth.test.mjs
+++ b/test/tcb-auth.test.mjs
@@ -37,10 +37,23 @@ test('recognizes CloudBase SDK 4 custom providers', async () => {
   assert.equal(await hasCustomLogin(auth), true)
 })
 
-test('rejects anonymous, missing, and unrelated providers', () => {
+test('hasCustomLogin returns false for non-custom users', async () => {
+  const anonymousAuth = {
+    getCurrentUser: async () => ({ providers: [{ id: 'anonymous' }] })
+  }
+  const missingUserAuth = { getCurrentUser: async () => null }
+
+  assert.equal(await hasCustomLogin(anonymousAuth), false)
+  assert.equal(await hasCustomLogin(missingUserAuth), false)
+})
+
+test('rejects missing, malformed, and unrelated providers', () => {
   assert.equal(isCustomUser(null), false)
   assert.equal(isCustomUser({}), false)
   assert.equal(isCustomUser({ providers: [{ id: 'anonymous' }] }), false)
+  assert.equal(isCustomUser({ providers: [null, {}] }), false)
+  assert.equal(isCustomUser({ providers: 'custom' }), false)
+  assert.equal(isCustomUser({ providers: { id: 'custom' } }), false)
 })
 
 test('keeps compatibility with the legacy custom login marker', () => {


### PR DESCRIPTION
## 变更内容

- 将匿名登录和自定义 Ticket 登录迁移到 CloudBase JS SDK 4 API。
- 使用 `getCurrentUser()` 获取当前用户，并通过 `providers[].id` 识别自定义登录身份。
- 集中管理 CloudBase 认证兼容逻辑，并增加 Node 回归测试。
- 将新增测试接入 CI。

## 根因

项目在 #1045 中将 `@cloudbase/js-sdk` 从 3.6.4 升级到了 4.0.0，但 CloudBase 登录流程仍在使用 SDK 3 的 Provider API 和 `getCurrenUser()`。

在 CloudBase 部署方式下，这会导致管理界面保留一个具有误导性的本地登录状态，但需要管理员权限的云函数请求仍被 Twikoo 以 `code: 1024（请先登录）` 拒绝。

SDK 4 提供的对应 API 是 `getCurrentUser()`、`signInAnonymously()`、`setCustomSignFunc()` 和 `signInWithCustomTicket()`；用户的登录来源则记录在 `providers[].id` 中。

## 验证结果

- `yarn test`：6 个测试全部通过。
- `yarn lint`：通过。
- `yarn build`：通过，仅有项目原本就存在的包体积警告。
- 使用 Twikoo 前后端 1.7.19 进行 CloudBase 实际集成验证：重新输入密码登录后，云函数返回 `IS_ADMIN=true`，并成功导入一条 Disqus 评论。

本次修改不涉及服务端鉴权、数据库权限或部署配置。

## Summary by Sourcery

更新 CloudBase 认证处理，以兼容 SDK 4，并可靠识别自定义管理员会话。

Bug 修复：
- 将 CloudBase 匿名登录和自定义 ticket 登录流程迁移到 SDK 4 的认证 API。
- 通过使用 `getCurrentUser()` 和 provider 标识符修正自定义用户检测逻辑，同时保持对旧有标记的兼容。

增强：
- 将 CloudBase 认证兼容逻辑集中化，便于在各个客户端组件中复用。

CI：
- 在 CI 中运行新的认证测试，并将测试文件纳入 lint 检查。

测试：
- 添加 Node 测试，覆盖匿名登录、自定义 ticket 登录和自定义用户检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CloudBase authentication handling for SDK 4 compatibility and reliably identify custom-admin sessions.

Bug Fixes:
- Migrate CloudBase authentication flows to the SDK 4 APIs for anonymous and custom-ticket sign-in.
- Correct custom-user detection by using getCurrentUser() and provider identifiers while retaining legacy marker compatibility.

Enhancements:
- Centralize CloudBase authentication compatibility logic for reuse across client components.

CI:
- Run the new authentication tests in CI and include test files in linting.

Tests:
- Add Node tests covering anonymous login, custom-ticket login, and custom-user detection.

</details>
