### PR TITLE
fix(chore): fix webpack regex for windows path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ function getConfig ({ extractCss }) {
           ? { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
           : { test: /\.css$/, use: ['vue-style-loader', 'css-loader'] },
         { test: /\.svg$/, loader: 'svg-inline-loader' },
-        { test: /\.js$/, exclude: /node_modules\/(webpack|webpack-dev-server|webpack-cli)\//, use: { loader: 'babel-loader', options: { presets: ['@babel/preset-env'], plugins: ['@babel/plugin-transform-modules-commonjs', '@babel/transform-runtime'] } } }
+        { test: /\.js$/, exclude: /node_modules[\\/](webpack|webpack-dev-server|webpack-cli)[\\/]/, use: { loader: 'babel-loader', options: { presets: ['@babel/preset-env'], plugins: ['@babel/plugin-transform-modules-commonjs', '@babel/transform-runtime'] } } }
       ]
     },
     entry: extractCss


### PR DESCRIPTION
> You may need to use `[\\/]` in regex to match `\` on Windows and `/` on Mac/Linux.

https://webpack.js.org/configuration/module#modulenoparse

## Sourcery 总结

错误修复：
- 更新 webpack 模块排除模式，使其能够识别 Windows 和 POSIX 路径分隔符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update the webpack module exclusion pattern to recognize both Windows and POSIX path separators.

</details>