### PR TITLE
chore: 删除错误的 IE8 / Safari 10 兼容

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,5 @@ Vue 2 + Element UI 组件，Webpack 5 构建为 UMD 库。两个入口：
 
 ## 注意事项
 
-- 构建目标兼容 ES5（IE8 / Safari 10），使用 Babel + Terser
 - `twikoo-func` 是服务端各后端共用的核心包，修改其 `utils/` 会影响所有部署方式
 - CloudBase 部署配置在 `cloudbaserc.json`，函数运行时 Node.js 16.13

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,9 +54,7 @@ function getConfig ({ extractCss }) {
         parallel: 4,
         terserOptions: {
           ecma: 5,
-          toplevel: true,
-          ie8: true,
-          safari10: true
+          toplevel: true
         }
       })
     ],


### PR DESCRIPTION
- 项目使用的vue2不兼容IE8
- 项目使用的ES6语法不兼容IE8 / Safari 10
- Terser的这两个功能是让兼容IE8的代码在压缩后继续兼容IE8，不是让不兼容IE8的代码兼容
- 目前生成的产物实际上也使用 `let` `??` 等ES6语法

## Sourcery 总结

从构建配置和文档中移除不受支持的 IE8 和 Safari 10 兼容性设置。

增强功能：
- 移除不正确的 IE8 和 Safari 10 兼容性声明及相应的压缩器设置。

构建：
- 使压缩配置与项目实际的 ES5 构建目标保持一致，同时保留标准的 ECMAScript 5 输出设置。

文档：
- 更新构建文档，移除不准确的 IE8 和 Safari 10 兼容性目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unsupported IE8 and Safari 10 compatibility settings from the build configuration and documentation.

Enhancements:
- Remove incorrect IE8 and Safari 10 compatibility claims and corresponding minifier settings.

Build:
- Align minification configuration with the project's actual ES5 build target while retaining standard ECMAScript 5 output settings.

Documentation:
- Update build documentation to remove the inaccurate IE8 and Safari 10 compatibility target.

</details>