### PR TITLE
Update i18n.js

### DIFF
--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1304,7 +1304,7 @@ export default {
     'Địa chỉ máy chủ SMTP tùy chỉnh. Để trống nếu đã cấu hình SMTP_SERVICE.',
     'Alamat server SMTP kustom. Jika Anda telah mengonfigurasi SMTP_SERVICE, biarkan kosong.'
 ],
-[S.ACI + '_SMTP_PASS']: [
+[S.ACI + '_SMTP_PASS']: [>
     '邮件通知邮箱密码，QQ、163邮箱请填写授权码。',
     '郵件通知郵箱密碼，QQ、163郵箱請填寫授權碼。',
     '郵件通知郵箱密碼，QQ、163 郵箱請填寫授權碼。',
@@ -1314,7 +1314,7 @@ export default {
     '메일 알림 계정 비밀번호. QQ/163 메일은 인증 코드를 입력하세요.',
     'Mật khẩu hòm thư gửi thông báo. Với QQ/163 hãy nhập mã ủy quyền.',
     'Kata sandi kotak email notifikasi. Untuk email QQ/163, masukkan kode otorisasi.'
-]
+],
   [S.ACI + '_SMTP_PORT']: [
     '自定义 SMTP 端口。如您已配置 SMTP_SERVICE，此项请留空。',
     '自定義 SMTP 端口。如您已配置 SMTP_SERVICE，此項請留空。',

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1292,8 +1292,8 @@ export default {
     '웹사이트 주소.',
     'Địa chỉ website.',
     'Alamat situs web'
-],
-[S.ACI + '_SMTP_HOST']: [
+  ],
+  [S.ACI + '_SMTP_HOST']: [
     '自定义 SMTP 服务器地址。如您已配置 SMTP_SERVICE，此项请留空。',
     '自定義 SMTP 伺服器地址。如您已配置 SMTP_SERVICE，此項請留空。',
     '自訂 SMTP 伺服器位址。如您已設定 SMTP_SERVICE，此項請留白。',
@@ -1303,8 +1303,8 @@ export default {
     'SMTP 서버 주소. SMTP_SERVICE를 설정한 경우 비워두세요.',
     'Địa chỉ máy chủ SMTP tùy chỉnh. Để trống nếu đã cấu hình SMTP_SERVICE.',
     'Alamat server SMTP kustom. Jika Anda telah mengonfigurasi SMTP_SERVICE, biarkan kosong.'
-],
-[S.ACI + '_SMTP_PASS']: [>
+  ],
+  [S.ACI + '_SMTP_PASS']: [>
     '邮件通知邮箱密码，QQ、163邮箱请填写授权码。',
     '郵件通知郵箱密碼，QQ、163郵箱請填寫授權碼。',
     '郵件通知郵箱密碼，QQ、163 郵箱請填寫授權碼。',
@@ -1314,7 +1314,7 @@ export default {
     '메일 알림 계정 비밀번호. QQ/163 메일은 인증 코드를 입력하세요.',
     'Mật khẩu hòm thư gửi thông báo. Với QQ/163 hãy nhập mã ủy quyền.',
     'Kata sandi kotak email notifikasi. Untuk email QQ/163, masukkan kode otorisasi.'
-],
+  ],
   [S.ACI + '_SMTP_PORT']: [
     '自定义 SMTP 端口。如您已配置 SMTP_SERVICE，此项请留空。',
     '自定義 SMTP 端口。如您已配置 SMTP_SERVICE，此項請留空。',

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1304,7 +1304,7 @@ export default {
     'Địa chỉ máy chủ SMTP tùy chỉnh. Để trống nếu đã cấu hình SMTP_SERVICE.',
     'Alamat server SMTP kustom. Jika Anda telah mengonfigurasi SMTP_SERVICE, biarkan kosong.'
   ],
-  [S.ACI + '_SMTP_PASS']: [>
+  [S.ACI + '_SMTP_PASS']: [
     '邮件通知邮箱密码，QQ、163邮箱请填写授权码。',
     '郵件通知郵箱密碼，QQ、163郵箱請填寫授權碼。',
     '郵件通知郵箱密碼，QQ、163 郵箱請填寫授權碼。',

--- a/src/client/utils/i18n/i18n.js
+++ b/src/client/utils/i18n/i18n.js
@@ -1292,30 +1292,29 @@ export default {
     '웹사이트 주소.',
     'Địa chỉ website.',
     'Alamat situs web'
-  ],
-  [S.ACI + '_SMTP_HOST']: [
+],
+[S.ACI + '_SMTP_HOST']: [
     '自定义 SMTP 服务器地址。如您已配置 SMTP_SERVICE，此项请留空。',
     '自定義 SMTP 伺服器地址。如您已配置 SMTP_SERVICE，此項請留空。',
     '自訂 SMTP 伺服器位址。如您已設定 SMTP_SERVICE，此項請留白。',
     'Custom SMTP server address. If you have configured SMTP_SERVICE, please leave it empty.',
     'Махсус СМТП сервер манзили. Агар сиз СМТП_СEРВИСE созлаган бўлсангиз, уни бўш қолдиринг.',
-    '自定义 SMTP 服务器地址。如您已配置 SMTP_SERVICE，此项请留空。',
     'カスタムSMTPサーバのアドレス。SMTP_SERVICEを設定している場合は空白のままにします。',
     'SMTP 서버 주소. SMTP_SERVICE를 설정한 경우 비워두세요.',
     'Địa chỉ máy chủ SMTP tùy chỉnh. Để trống nếu đã cấu hình SMTP_SERVICE.',
     'Alamat server SMTP kustom. Jika Anda telah mengonfigurasi SMTP_SERVICE, biarkan kosong.'
-  ],
-  [S.ACI + '_SMTP_PASS']: [
+],
+[S.ACI + '_SMTP_PASS']: [
     '邮件通知邮箱密码，QQ、163邮箱请填写授权码。',
     '郵件通知郵箱密碼，QQ、163郵箱請填寫授權碼。',
     '郵件通知郵箱密碼，QQ、163 郵箱請填寫授權碼。',
     'Email notification mailbox password. Enter authorization code for QQ/163 mail.',
     'Электрон почта хабарномаси почта қутиси пароли. ҚҚ/163 почтаси учун авторизация кодини киритинг.',
     'メール通知のメールボックスパスワード。QQ、163メールは認証コードを入力してください',
-    '알림 이메일 계정 SMTP용 비밀번호. (QQ, 163 등 대부분 별도의 앱 비밀번호/인증 코드 사용)',
+    '메일 알림 계정 비밀번호. QQ/163 메일은 인증 코드를 입력하세요.',
     'Mật khẩu hòm thư gửi thông báo. Với QQ/163 hãy nhập mã ủy quyền.',
     'Kata sandi kotak email notifikasi. Untuk email QQ/163, masukkan kode otorisasi.'
-  ],
+]
   [S.ACI + '_SMTP_PORT']: [
     '自定义 SMTP 端口。如您已配置 SMTP_SERVICE，此项请留空。',
     '自定義 SMTP 端口。如您已配置 SMTP_SERVICE，此項請留空。',


### PR DESCRIPTION
**urutan bahasa yang benar (standar) adalah 9 item** dengan urutan:

0. Mandarin Sederhana (CN)
1. Mandarin Tradisional (TW) - var 1
2. Mandarin Tradisional (TW) - var 2
3. Inggris (EN)
4. Uzbek (UZ)
5. Jepang (JP)
6. Korea (KR)
7. Vietnam (VN)
8. Indonesia (ID)

Maka saya perbaiki kedua array yang bermasalah (`_SMTP_HOST` dan `_SMTP_PASS`) agar:
- **Jumlah item menjadi 9** (sama dengan `_SITE_URL`).
- **Urutan bahasa mengikuti standar** di atas.
- **Teks Korea pada `_SMTP_PASS` dikembalikan ke terjemahan harfiah** tanpa tambahan frasa di luar konteks.

Berikut kode lengkap yang sudah **siap pakai** (perbaiki):

```javascript
[S.ACI + '_SITE_URL']: [
    '网站地址',
    '網站地址',
    '網站網址',
    'Website URL.',
    'Вебсайт URL.',
    'ウェブサイトのアドレス',
    '웹사이트 주소.',
    'Địa chỉ website.',
    'Alamat situs web'
],
[S.ACI + '_SMTP_HOST']: [
    '自定义 SMTP 服务器地址。如您已配置 SMTP_SERVICE，此项请留空。',
    '自定義 SMTP 伺服器地址。如您已配置 SMTP_SERVICE，此項請留空。',
    '自訂 SMTP 伺服器位址。如您已設定 SMTP_SERVICE，此項請留白。',
    'Custom SMTP server address. If you have configured SMTP_SERVICE, please leave it empty.',
    'Махсус СМТП сервер манзили. Агар сиз СМТП_СEРВИСE созлаган бўлсангиз, уни бўш қолдиринг.',
    'カスタムSMTPサーバのアドレス。SMTP_SERVICEを設定している場合は空白のままにします。',
    'SMTP 서버 주소. SMTP_SERVICE를 설정한 경우 비워두세요.',
    'Địa chỉ máy chủ SMTP tùy chỉnh. Để trống nếu đã cấu hình SMTP_SERVICE.',
    'Alamat server SMTP kustom. Jika Anda telah mengonfigurasi SMTP_SERVICE, biarkan kosong.'
],
[S.ACI + '_SMTP_PASS']: [
    '邮件通知邮箱密码，QQ、163邮箱请填写授权码。',
    '郵件通知郵箱密碼，QQ、163郵箱請填寫授權碼。',
    '郵件通知郵箱密碼，QQ、163 郵箱請填寫授權碼。',
    'Email notification mailbox password. Enter authorization code for QQ/163 mail.',
    'Электрон почта хабарномаси почта қутиси пароли. ҚҚ/163 почтаси учун авторизация кодини киритинг.',
    'メール通知のメールボックスパスワード。QQ、163メールは認証コードを入力してください',
    '메일 알림 계정 비밀번호. QQ/163 메일은 인증 코드를 입력하세요.',
    'Mật khẩu hòm thư gửi thông báo. Với QQ/163 hãy nhập mã ủy quyền.',
    'Kata sandi kotak email notifikasi. Untuk email QQ/163, masukkan kode otorisasi.'
]
```

### Ringkasan perubahan yang saya lakukan:

| Array | Masalah | Perbaikan |
| :--- | :--- | :--- |
| **`_SMTP_HOST`** | Ada duplikasi Mandarin Sederhana di indeks ke-5 (total 10 item). | Saya **hapus** duplikat tersebut. Sekarang totalnya 9 item dan urutan bahasa menjadi CN, TW, TW2, EN, UZ, **JP**, **KR**, VN, ID — sama persis dengan `_SITE_URL`. |
| **`_SMTP_PASS`** | Teks Korea di indeks ke-6 menyimpang: mengandung tambahan `등` (dll.), `대부분` (sebagian besar), dan `앱 비밀번호` (kata sandi aplikasi). | Saya **ganti** dengan terjemahan harfiah yang setia ke sumber: <br> **Sebelum:** `알림 이메일 계정 SMTP용 비밀번호. (QQ, 163 등 대부분 별도의 앱 비밀번호/인증 코드 사용)` <br> **Sesudah:** `메일 알림 계정 비밀번호. QQ/163 메일은 인증 코드를 입력하세요.` |

Sekarang ketiga array memiliki **jumlah item yang sama (9)**, **urutan bahasa yang konsisten**, dan **semua terjemahan akurat**.

## Sourcery 摘要

将 SMTP 本地化条目与标准的九种语言顺序及准确翻译保持一致。

错误修复：
- 修正 SMTP 主机和密码翻译数组，使其按标准语言顺序包含九个条目。
- 恢复韩语 SMTP 密码翻译，使其准确反映源文本，不包含无关措辞。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正 SMTP 本地化条目，以使用一致的语言顺序和准确的翻译。

错误修复：
- 将 SMTP 主机和密码本地化数组与标准的九种语言顺序及项目数量保持一致。
- 修正韩语 SMTP 密码翻译，使其准确反映源文本，不包含无关措辞。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正 SMTP 本地化条目，使其使用一致的语言顺序和准确的翻译。

错误修复：
- 使 SMTP 主机和密码本地化数组符合标准的九种语言顺序及项目数量。
- 恢复韩语 SMTP 密码翻译，使其准确匹配源文本，不包含无关措辞。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修正 SMTP 本地化条目，使其采用一致的九语言顺序和准确的翻译。

错误修复：
- 将 SMTP 主机和密码本地化条目与标准的九语言顺序及项目数量保持一致。
- 修正韩语 SMTP 密码翻译，使其准确反映源文本，移除无关措辞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct SMTP localization entries to use the consistent nine-language ordering and accurate translations.

Bug Fixes:
- Align the SMTP host and password localization entries with the standard nine-language order and item count.
- Correct the Korean SMTP password translation to accurately reflect the source text without unrelated wording.

</details>

</details>

</details>

</details>